### PR TITLE
cleanup exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,8 @@
 'use strict';
 
-var Connection = require('node-xmpp-core').Connection
-  , Client = require('node-xmpp-client')
-  , Component = require('node-xmpp-component')
-  , C2SServer = require('node-xmpp-server').C2SServer
-  , C2SStream = require('node-xmpp-server').C2SStream
-  , JID = require('node-xmpp-core').JID
-  , Router = require('node-xmpp-server').Router
-  , ltx = require('ltx')
-  , Stanza = require('node-xmpp-core').Stanza
+var extend = require('util')._extend
 
-exports.Connection = Connection
-exports.Client = Client
-exports.Component = Component
-exports.C2SServer = C2SServer
-exports.C2SStream = C2SStream
-exports.JID = JID
-exports.Element = ltx.Element
-exports.Stanza = Stanza.Stanza
-exports.Message = Stanza.Message
-exports.Presence = Stanza.Presence
-exports.Iq = Stanza.Iq
-exports.Router = Router
-exports.BOSHServer = require('node-xmpp-server').BOSHServer
-exports.StreamParser = require('node-xmpp-core').StreamParser
+extend(exports, require('node-xmpp-core'))
+extend(exports,  require('node-xmpp-server'))
+exports.Client = require('node-xmpp-client')
+exports.Component = require('node-xmpp-component')


### PR DESCRIPTION
since node-xmpp/node-xmpp-core#46 is cleaning up the api, it makes it much easier to pass the api in  index.js.