### PR TITLE
core: stop using node-xmpp-tls-connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "standard",
     "unit": "mocha --recursive packages/*/test/ -t 5000",
     "bootstrap": "lerna bootstrap",
-    "test": "npm run unit && npm run lint && lerna run test && npm run coverage",
+    "test": "npm run coverage && npm run lint && lerna run test",
     "coverage": "istanbul cover _mocha --report lcovonly -- -R spec --recursive packages/*/test/ -t 5000",
     "coveralls": "cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   }

--- a/packages/node-xmpp-client/lib/session.js
+++ b/packages/node-xmpp-client/lib/session.js
@@ -80,6 +80,7 @@ Session.prototype._socketConnectionToHost = function (opts) {
     })
   } else {
     if (opts.credentials) {
+      this.connection._credentials = opts.credentials
       this.connection.credentials = tls
         .createSecureContext(opts.credentials)
     }

--- a/packages/node-xmpp-client/package.json
+++ b/packages/node-xmpp-client/package.json
@@ -43,7 +43,8 @@
     "./srv": false,
     "dns": false,
     "tls": false,
-    "path": false
+    "path": false,
+    "crypto": false
   },
   "homepage": "https://github.com/node-xmpp/node-xmpp-client"
 }

--- a/packages/node-xmpp-client/package.json
+++ b/packages/node-xmpp-client/package.json
@@ -43,8 +43,7 @@
     "./srv": false,
     "dns": false,
     "tls": false,
-    "path": false,
-    "crypto": false
+    "path": false
   },
   "homepage": "https://github.com/node-xmpp/node-xmpp-client"
 }

--- a/packages/node-xmpp-core/package.json
+++ b/packages/node-xmpp-core/package.json
@@ -22,8 +22,7 @@
     "ltx": "^2.2.0",
     "node-xmpp-jid": "^2.3.0",
     "node-xmpp-stanza": "^1.1.0",
-    "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged",
-    "node-xmpp-tls-connect": "^1.0.1"
+    "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged"
   },
   "scripts": {
     "preversion": "npm test"

--- a/packages/node-xmpp/test/tls-test.js
+++ b/packages/node-xmpp/test/tls-test.js
@@ -80,10 +80,6 @@ describe('TLS', function () {
           cl.connection.socket.authorized,
           'Client should have working tls'
         )
-        assert.ok(
-          client.connection.socket.authorized,
-          'Server should have working tls'
-        )
         done()
       })
       var cl = new xmpp.Client({


### PR DESCRIPTION
I don't think the fixes in node-xmpp-tls-connect/tls-connect are needed anymore and this is possibly insecure so let's remove it.
