### PR TITLE
Allow passing websocket options through

### DIFF
--- a/packages/node-xmpp-client/lib/websockets.js
+++ b/packages/node-xmpp-client/lib/websockets.js
@@ -21,7 +21,7 @@ function WSConnection (opts) {
   this.xmlns = {
     '': NS_FRAMING
   }
-  this.websocket = new WebSocket(this.url, ['xmpp'])
+  this.websocket = new WebSocket(this.url, ['xmpp'], opts.websocket.options)
   this.websocket.onopen = this.onopen.bind(this)
   this.websocket.onmessage = this.onmessage.bind(this)
   this.websocket.onclose = this.onclose.bind(this)


### PR DESCRIPTION
This PR allows passing of websocket options. This allows configuration of the Faye websocket. In my case, I am using this to enable permessage-deflate compression. I opened another pull for this in the wrong repo previously (https://github.com/node-xmpp/client/pull/210)
