### PR TITLE
Added node minimum requirement to package.json

### DIFF
--- a/packages/node-xmpp-client/package.json
+++ b/packages/node-xmpp-client/package.json
@@ -34,5 +34,8 @@
     "ws": false,
     "path": false,
     "crypto": false
+  },
+  "engines" : {
+    "node" : ">=0.12.15"
   }
 }

--- a/packages/node-xmpp-server/package.json
+++ b/packages/node-xmpp-server/package.json
@@ -26,5 +26,8 @@
     "async": "^2.0.0-rc.5",
     "node-xmpp-client": "^3.0.0",
     "node-xmpp-component": "^2.0.1"
+  },
+  "engines" : {
+    "node" : ">=0.12.15"
   }
 }


### PR DESCRIPTION
This is necessary because `tls.createSecureContext(options)` was added in v0.11.13. Not sure if there are any other things that would require a higher version.

Maybe 0.12.x might be better because that's the minimum being tested against?
