### PR TITLE
@xmpp/component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ script:
   - sudo prosodyctl start
   - npm run integration
   - sudo prosodyctl restart
+  - npm run ava:integration
+  - sudo prosodyctl restart
   - npm run bundle
   - npm run test:browser
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ node-xmpp is a set of XMPP libraries for JavaScript.
 - [node-xmpp-component](https://github.com/node-xmpp/node-xmpp/tree/master/packages/node-xmpp-component)
 - [node-xmpp-core](https://github.com/node-xmpp/node-xmpp/tree/master/packages/node-xmpp-core)
 - [@xmpp/xml](https://github.com/node-xmpp/node-xmpp/tree/master/packages/xml)
+- [@xmpp/component](https://github.com/node-xmpp/node-xmpp/tree/master/packages/component)
 - [@xmpp/streamparser](https://github.com/node-xmpp/node-xmpp/tree/master/packages/streamparser)
 - [@xmpp/jid](https://github.com/node-xmpp/node-xmpp/tree/master/packages/jid)
 - [@xmpp/time](https://github.com/node-xmpp/node-xmpp/tree/master/packages/time)

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,9 @@
     "ignore": [
       "ava/",
       "examples/",
-      "test/"
+      "test/",
+      "example.js",
+      "test.js"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "ava": "^0.17.0",
+    "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.18.0",
     "browserify": "^13.0.1",
@@ -18,6 +19,7 @@
   },
   "scripts": {
     "ava": "ava",
+    "ava:integration": "ava test/ava/**/*.js",
     "postinstall": "npm run bootstrap",
     "lint": "standard",
     "unit": "mocha --recursive packages/*/test/ -t 5000",
@@ -33,10 +35,8 @@
     "require": "babel-register",
     "babel": "inherit",
     "files": [
-      "packages/*/ava/**/*.js"
+      "packages/*/ava/*.js",
+      "packages/*/ava/unit/**/*.js"
     ]
-  },
-  "dependencies": {
-    "babel-polyfill": "^6.16.0"
   }
 }

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -1,0 +1,18 @@
+# component
+
+XMPP component for JavaScript
+
+## Install
+
+```
+npm install @xmpp/component
+```
+
+## Usage
+
+See [example.js](https://github.com/node-xmpp/node-xmpp/tree/master/packages/component/example.js)
+
+## References
+
+* [XEP-0114: Jabber Component Protocol](https://xmpp.org/extensions/xep-0114.html) implemented
+* [XEP-0225: Component Connections](https://xmpp.org/extensions/xep-0225.html) todo

--- a/packages/component/example.js
+++ b/packages/component/example.js
@@ -1,0 +1,91 @@
+/* eslint-disable */
+
+'use strict'
+
+const xml = require('../xml') // require('@xmpp/xml')
+const Component = require('../component') // require('@xmpp/component')
+const entity = new Component()
+
+// emitted for any error
+entity.once('error', (err) => {
+  console.error('error', err)
+})
+
+// emitted for incoming stanza _only_ (iq/presence/message) qualified with the right namespace
+// entity.on('stanza', (stanza) => {
+//   console.log('stanza', stanza.toString())
+// })
+
+// emitted for incoming nonza _only_
+// entity.on('nonza', (nonza) => {
+//   console.log('nonza', nonza.toString())
+// })
+
+// emitted for any in our out XML fragment
+// useful for logging raw XML traffic
+entity.on('fragment', (input, output) => {
+  console.log(output ? '=>' : '<=', (output || input).trim())
+})
+
+// emitted for any in our out XML root element
+// useful for logging
+// entity.on('element', (input, output) => {
+//   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
+// })
+
+// emitted when the socket is open
+entity.on('connect', () => {
+  console.log('1. connected')
+})
+
+// emitted when the XMPP stream has open and we received the server stream
+entity.on('open', (el) => {
+  console.log('2. open')
+})
+
+// emitted when the XMPP entity is authenticated
+entity.on('authenticated', () => {
+  console.log('3. authenticated')
+})
+
+// emitted when the XMPP entity is ready
+entity.on('ready', () => {
+  console.log('4. ready')
+})
+
+// emitted when ready, authenticated and bound
+entity.on('online', (jid) => {
+  console.log('5. online', jid.toString())
+
+  entity.send(xml`
+    <iq to='localhost' id='ping' type='get'>
+      <ping xmlns='urn:xmpp:ping'/>
+    </iq>
+  `)
+})
+
+// "start" opens the socket and the XML stream
+entity.start('xmpp:component.localhost:5347')
+  // resolves once online
+  .then((jid) => {
+    console.log('started', jid.toString())
+  })
+  // rejects for any error before online
+  .catch(err => {
+    console.error('start failed', err)
+  })
+
+// emitted when authentication is required
+entity.on('authenticate', authenticate => {
+  authenticate('mysecretcomponentpassword')
+    .then(() => {
+      console.log('authenticated')
+    })
+    .catch((err) => {
+      console.error('authentication failed', err)
+    })
+})
+
+process.on('unhandledRejection', function (reason, p) {
+  console.log('Possibly Unhandled Rejection at: Promise ', p, ' reason: ', reason)
+})

--- a/packages/component/index.js
+++ b/packages/component/index.js
@@ -1,0 +1,64 @@
+const Connection = require('@xmpp/connection-tcp')
+const url = require('url')
+const crypto = require('crypto')
+const {tagString, Element, tag} = require('@xmpp/xml')
+
+/*
+ * References
+ * https://xmpp.org/extensions/xep-0114.html
+ */
+
+const NS = 'jabber:component:accept'
+
+class Component extends Connection {
+  connect (uri) {
+    const {hostname, port} = url.parse(uri)
+    return super.connect({port: port || 5347, hostname})
+  }
+
+  header (domain, lang) {
+    return tagString`
+      <?xml version='1.0'?>
+      <stream:stream to='${domain}' xml:lang='${lang}' xmlns='${this.NS}' xmlns:stream='${super.NS}'>
+    `
+  }
+
+  waitHeader (domain, lang, fn) {
+    const handler = (name, attrs) => {
+      if (name !== 'stream:stream') return // FIXME error
+      // disabled because component doesn't use this
+      // if (attrs.version !== '1.0') return // FIXME error
+      if (attrs.xmlns !== this.NS) return // FIXME error
+      if (attrs['xmlns:stream'] !== super.NS) return // FIXME error
+      if (attrs.from !== domain) return // FIXME error
+      if (!attrs.id) return // FIXME error
+      this.id = attrs.id
+      fn(null, new Element(name, attrs))
+      this.emit('authenticate', (secret) => {
+        return this.authenticate(secret)
+      })
+    }
+    this.parser.once('startElement', handler)
+  }
+
+  // FIXME move to module?
+  authenticate (password) {
+    const hash = crypto.createHash('sha1')
+    hash.update(this.id + password, 'binary')
+    return this.sendReceive(tag`<handshake>${hash.digest('hex')}</handshake>`)
+      .then((el) => {
+        if (el.name !== 'handshake') {
+          throw new Error('unexpected stanza')
+        }
+        this._authenticated()
+        this._jid(this._domain)
+        this._ready()
+        this._online() // FIXME should be emitted after promise resolve
+      })
+  }
+}
+
+Component.NS = NS
+Component.prototype.NS = NS
+
+module.exports = Component

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@xmpp/component",
+  "description": "XMPP component for JavaScript",
+  "repository": "github:node-xmpp/node-xmpp",
+  "homepage": "https://github.com/node-xmpp/node-xmpp/tree/master/packages/component",
+  "bugs": "http://github.com/node-xmpp/node-xmpp/issues",
+  "version": "0.0.0",
+  "license": "ISC",
+  "keywords": [
+    "XMPP",
+    "component"
+  ],
+  "dependencies": {
+    "@xmpp/connection-tcp": "^0.0.0",
+    "@xmpp/xml": "^0.0.1"
+  }
+}

--- a/packages/connection-tcp/ava/Connection.js
+++ b/packages/connection-tcp/ava/Connection.js
@@ -1,0 +1,68 @@
+const test = require('ava')
+const _Connection = require('../../../packages/connection')
+const Connection = require('..')
+const xml = require('@xmpp/xml')
+const net = require('net')
+const StreamParser = require('../lib/StreamParser')
+
+const NS_STREAM = 'http://etherx.jabber.org/streams'
+
+test('new Connection()', t => {
+  const conn = new Connection()
+  t.true(conn instanceof _Connection)
+  t.is(conn.NS, NS_STREAM)
+})
+
+test.cb('waitHeader', t => {
+  const conn = new Connection()
+  conn.NS = 'foo:bar'
+  conn.waitHeader('domain', 'lang', t.end)
+  conn.parser.emit('startElement', 'stream:stream', {
+    xmlns: 'foo:bar',
+    'xmlns:stream': NS_STREAM,
+    from: 'domain',
+    id: 'some-id'
+  })
+})
+
+test('Socket', t => {
+  const conn = new Connection()
+  conn.Socket = net.Socket
+})
+
+test('Parser', t => {
+  const conn = new Connection()
+  conn.Parser = StreamParser
+})
+
+test('NS', t => {
+  t.is(Connection.NS, NS_STREAM)
+})
+
+test('header()', t => {
+  const conn = new Connection()
+  conn.NS = 'foobar'
+  t.is(conn.header('foo', 'bar'),
+    xml.tagString`
+      <?xml version='1.0'?>
+      <stream:stream to='foo' version='1.0' xml:lang='bar' xmlns='foobar' xmlns:stream='${NS_STREAM}'>
+    `
+  )
+})
+
+test('footer()', t => {
+  const conn = new Connection()
+  t.is(conn.footer(), '<stream:stream/>')
+})
+
+test('match()', t => {
+  t.is(Connection.match('xmpp:foobar'), 'xmpp:foobar')
+  t.is(Connection.match('xmpp://foobar'), 'xmpp://foobar')
+  t.is(Connection.match('xmpp:foobar:5222'), 'xmpp:foobar:5222')
+
+  t.is(Connection.match('foobar:2222'), false)
+  t.is(Connection.match('ws://foobar:2222'), false)
+  t.is(Connection.match('wss://foobar:2222'), false)
+  t.is(Connection.match('http://foobar:2222'), false)
+  t.is(Connection.match('https://foobar:2222'), false)
+})

--- a/packages/connection-tcp/index.js
+++ b/packages/connection-tcp/index.js
@@ -1,0 +1,60 @@
+const Socket = require('net').Socket
+const Connection = require('@xmpp/connection')
+const StreamParser = require('./lib/StreamParser')
+const {tagString, Element} = require('@xmpp/xml')
+
+const NS_STREAM = 'http://etherx.jabber.org/streams'
+
+/* References
+ * Extensible Messaging and Presence Protocol (XMPP): Core http://xmpp.org/rfcs/rfc6120.html
+*/
+
+class TCP extends Connection {
+  // FIXME is lang useful?
+  // https://xmpp.org/rfcs/rfc6120.html#streams-open
+  waitHeader (domain, lang, fn) {
+    const handler = (name, attrs) => {
+      if (name !== 'stream:stream') return // FIXME error
+      // disabled because component doesn't use this
+      // if (attrs.version !== '1.0') return // FIXME error
+      if (attrs.xmlns !== this.NS) return // FIXME error
+      if (attrs['xmlns:stream'] !== NS_STREAM) return // FIXME error
+      if (attrs.from !== domain) return // FIXME error
+      if (!attrs.id) return // FIXME error
+      fn(null, new Element(name, attrs))
+    }
+    this.parser.once('startElement', handler)
+  }
+
+  // https://xmpp.org/rfcs/rfc6120.html#streams-open
+  header (domain, lang) {
+    return tagString`
+      <?xml version='1.0'?>
+      <stream:stream to='${domain}' version='1.0' xml:lang='${lang}' xmlns='${this.NS}' xmlns:stream='${NS_STREAM}'>
+    `
+  }
+
+  // // https://xmpp.org/rfcs/rfc6120.html#streams-close
+  // waitFooter (fn) {
+  //   this.parser.once('endElement', (name) => {
+  //     if (name !== 'stream:stream') return // FIXME error
+  //     fn()
+  //   })
+  // }
+
+  // https://xmpp.org/rfcs/rfc6120.html#streams-close
+  footer () {
+    return '<stream:stream/>'
+  }
+
+  static match (uri) {
+    return uri.startsWith('xmpp:') ? uri : false
+  }
+}
+
+TCP.NS = NS_STREAM
+TCP.prototype.NS = NS_STREAM
+TCP.prototype.Socket = Socket
+TCP.prototype.Parser = StreamParser
+
+module.exports = TCP

--- a/packages/connection-tcp/lib/StreamParser.js
+++ b/packages/connection-tcp/lib/StreamParser.js
@@ -1,0 +1,33 @@
+const _StreamParser = require('@xmpp/streamparser')
+
+/*
+ * hack for most usecases, do we have a better idea?
+ *   catch the following:
+ *   <?xml version="1.0"?>
+ *   <?xml version="1.0" encoding="UTF-8"?>
+ *   <?xml version="1.0" encoding="UTF-16" standalone="yes"?>
+ */
+function removeXMLHeader (data) {
+  // check for xml tag
+  const index = data.indexOf('<?xml')
+
+  if (index !== -1) {
+    const end = data.indexOf('?>')
+    if (index >= 0 && end >= 0 && index < end + 2) {
+      const search = data.substring(index, end + 2)
+      data = data.replace(search, '')
+    }
+  }
+
+  return data
+}
+
+class StreamParser extends _StreamParser {
+  write (data) {
+    data = data.toString('utf8')
+    data = removeXMLHeader(data) // FIXME only once
+    super.write(data)
+  }
+}
+
+module.exports = StreamParser

--- a/packages/connection-tcp/package.json
+++ b/packages/connection-tcp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@xmpp/connection-tcp",
+  "description": "XMPP TCP connection for JavaScript",
+  "repository": "github:node-xmpp/node-xmpp",
+  "homepage": "https://github.com/node-xmpp/node-xmpp/tree/master/packages/connection-tcp",
+  "bugs": "http://github.com/node-xmpp/node-xmpp/issues",
+  "version": "0.0.0",
+  "license": "ISC",
+  "keywords": [
+    "XMPP",
+    "connection",
+    "TCP"
+  ],
+  "dependencies": {
+    "@xmpp/connection": "^0.0.0",
+    "@xmpp/streamparser": "^0.0.1",
+    "@xmpp/xml": "^0.0.1"
+  }
+}

--- a/packages/connection/ava/test.js
+++ b/packages/connection/ava/test.js
@@ -1,0 +1,74 @@
+const test = require('ava')
+const Connection = require('..')
+const EventEmitter = require('events')
+const xml = require('@xmpp/xml')
+
+test('new Connection()', t => {
+  const conn = new Connection()
+  t.is(conn.online, false)
+  t.is(conn._domain, null)
+  t.is(conn.lang, null)
+  t.is(conn.jid, null)
+  t.is(conn.timeout, 2000)
+  t.true(conn instanceof EventEmitter)
+})
+
+test('isStanza()', t => {
+  const conn = new Connection()
+  conn.NS = 'bar'
+  conn.online = true
+
+  t.is(conn.isStanza(xml`<foo/>`), false)
+  t.is(conn.isStanza(xml`<foo xmlns='bar'/>`), false)
+
+  t.is(conn.isStanza(xml`<presence xmlns='foo'/>`), false)
+  t.is(conn.isStanza(xml`<iq xmlns='foo'/>`), false)
+  t.is(conn.isStanza(xml`<message xmlns='foo'/>`), false)
+
+  t.is(conn.isStanza(xml`<presence/>`), true)
+  t.is(conn.isStanza(xml`<iq/>`), true)
+  t.is(conn.isStanza(xml`<message/>`), true)
+
+  t.is(conn.isStanza(xml`<presence xmlns='bar'/>`), true)
+  t.is(conn.isStanza(xml`<iq xmlns='bar'/>`), true)
+  t.is(conn.isStanza(xml`<message xmlns='bar'/>`), true)
+
+  conn.online = false
+
+  t.is(conn.isStanza(xml`<presence/>`), false)
+  t.is(conn.isStanza(xml`<iq/>`), false)
+  t.is(conn.isStanza(xml`<message/>`), false)
+  t.is(conn.isStanza(xml`<presence xmlns='bar'/>`), false)
+  t.is(conn.isStanza(xml`<iq xmlns='bar'/>`), false)
+  t.is(conn.isStanza(xml`<message xmlns='bar'/>`), false)
+})
+
+test('isNonza()', t => {
+  const conn = new Connection()
+  conn.NS = 'bar'
+  conn.online = true
+
+  t.is(conn.isNonza(xml`<foo/>`), true)
+  t.is(conn.isNonza(xml`<foo xmlns='bar'/>`), true)
+
+  t.is(conn.isNonza(xml`<presence xmlns='foo'/>`), true)
+  t.is(conn.isNonza(xml`<iq xmlns='foo'/>`), true)
+  t.is(conn.isNonza(xml`<message xmlns='foo'/>`), true)
+
+  t.is(conn.isNonza(xml`<presence/>`), false)
+  t.is(conn.isNonza(xml`<iq/>`), false)
+  t.is(conn.isNonza(xml`<message/>`), false)
+
+  t.is(conn.isNonza(xml`<presence xmlns='bar'/>`), false)
+  t.is(conn.isNonza(xml`<iq xmlns='bar'/>`), false)
+  t.is(conn.isNonza(xml`<message xmlns='bar'/>`), false)
+
+  conn.online = false
+
+  t.is(conn.isNonza(xml`<presence/>`), true)
+  t.is(conn.isNonza(xml`<iq/>`), true)
+  t.is(conn.isNonza(xml`<message/>`), true)
+  t.is(conn.isNonza(xml`<presence xmlns='bar'/>`), true)
+  t.is(conn.isNonza(xml`<iq xmlns='bar'/>`), true)
+  t.is(conn.isNonza(xml`<message xmlns='bar'/>`), true)
+})

--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -1,0 +1,277 @@
+const EventEmitter = require('events')
+const StreamParser = require('@xmpp/streamparser')
+const JID = require('@xmpp/jid')
+const url = require('url')
+
+function error (name, message) {
+  const e = new Error(message)
+  e.name = name
+  return e
+}
+
+// we ignore url module from the browser bundle to reduce its size
+function getHostname (uri) {
+  if (url.parse) {
+    return url.parse(uri).hostname
+  } else {
+    const el = document.createElement('a')
+    el.href = uri
+    return el.hostname
+  }
+}
+
+class Connection extends EventEmitter {
+  constructor (options) {
+    super()
+    this.online = false
+    this._domain = null
+    this.lang = null
+    this.jid = null
+    this.timeout = 2000
+    this.options = typeof options === 'object' ? options : {}
+    this.plugins = []
+
+    if (this.Socket && this.Parser) {
+      this._handle(new this.Socket(), new this.Parser())
+    }
+  }
+
+  stop () {
+    return this.end()
+      .then(() => this.close())
+  }
+
+  _handle (socket, parser) {
+    const errorListener = (error) => {
+      this.emit('error', error)
+    }
+
+    // socket
+    const sock = this.socket = socket
+    const dataListener = (data) => {
+      data = data.toString('utf8')
+      this.parser.write(data)
+      // FIXME only if parser.write ok
+      this.emit('fragment', data)
+    }
+    const closeListener = () => {
+      this._domain = ''
+      this.online = false
+      this.emit('close')
+    }
+    const connectListener = () => {
+      this.online = true
+      this.emit('connect')
+    }
+    sock.on('data', dataListener)
+    sock.on('error', errorListener)
+    sock.on('close', closeListener)
+    sock.on('connect', connectListener)
+
+    // parser
+    this.parser = parser
+    const elementListener = (element) => {
+      if (element.name === 'stream:error') {
+        const condition = element.children[0].name
+        const textEl = element.getChild('text', 'urn:ietf:params:xml:ns:xmpp-streams')
+        this.emit('error', error(condition, textEl.text()))
+      }
+      this.emit('element', element)
+      this.emit(this.isStanza(element) ? 'stanza' : 'nonza', element)
+    }
+    parser.on('element', elementListener)
+    parser.on('error', errorListener)
+  }
+
+  _jid (jid) {
+    jid = JID(jid)
+    this.jid = jid
+    return jid
+  }
+
+  _ready () {
+    this.emit('ready', this.jid)
+  }
+
+  _online () {
+    this.emit('online', this.jid)
+  }
+
+  _authenticated () {
+    this.emit('authenticated')
+  }
+
+  id () {
+    return Math.random().toString().split('0.')[1]
+  }
+
+  /**
+   * opens the socket then opens the stream
+   */
+  start (options) {
+    return new Promise((resolve, reject) => {
+      if (typeof options === 'string') {
+        options = {uri: options}
+      }
+
+      if (!options.domain) {
+        options.domain = getHostname(options.uri)
+      }
+
+      this.connect(options.uri)
+        .then(() => {
+          this.open(options.domain, options.lang)
+            .then(() => {
+              // FIXME reject on error ?
+              this.once('ready', resolve)
+            }, reject)
+        }, reject)
+    })
+  }
+
+  /**
+   * opens the socket
+   */
+  connect (options) {
+    return new Promise((resolve, reject) => {
+      this.socket.connect(options, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+
+  /**
+   * opens the stream
+   */
+  open (domain, lang = 'en') {
+    return new Promise((resolve, reject) => {
+      // FIXME timeout
+      this.waitHeader(domain, lang, (err, el) => {
+        if (err) return reject(err)
+        this._domain = domain
+        this.lang = lang
+        this.emit('open', el)
+        resolve(el)
+      })
+      this.write(this.header(domain, lang))
+    })
+  }
+
+  /**
+   * restarts the stream
+   */
+  restart () {
+    return this.open(this.socket._domain, this.socket.lang)
+  }
+
+  _promise (event, timeout) {
+    return new Promise((resolve, reject) => {
+      let timer
+      const cleanup = () => {
+        this.removeListener(event, onEvent)
+        this.removeListener('error', onError)
+        clearTimeout(timer)
+      }
+      if (typeof timeout === 'number') {
+        timer = setTimeout(() => {
+          reject(error(
+            'TimeoutError',
+            `"${event}" event didn't fire within ${timeout}ms`
+          ))
+          cleanup()
+        }, timeout)
+      }
+      const onError = (reason) => {
+        reject(reason)
+        cleanup()
+      }
+      const onEvent = (value) => {
+        resolve(value)
+        cleanup()
+      }
+      this.once('error', onError)
+      this.once(event, onEvent)
+    })
+  }
+
+  send (element) {
+    return new Promise((resolve, reject) => {
+      this.write(element.root()).then(resolve, reject)
+    })
+  }
+
+  sendReceive (element, timeout = this.timeout) {
+    return new Promise((resolve, reject) => {
+      this.send(element).catch(reject)
+      this._promise('element', timeout).then(resolve, reject)
+    })
+  }
+
+  write (data) {
+    return new Promise((resolve, reject) => {
+      data = data.toString('utf8').trim()
+      this.socket.write(data, (err) => {
+        if (err) return reject(err)
+        this.emit('fragment', undefined, data)
+        resolve()
+      })
+    })
+  }
+
+  // FIXME maybe move to connection-tcp
+  writeReceive (data, timeout = this.timeout) {
+    return new Promise((resolve, reject) => {
+      this.write(data).catch(reject)
+      this._promise('element', timeout).then(resolve, reject)
+    })
+  }
+
+  isStanza (element) {
+    const {name} = element
+    return (
+      this.online &&
+      (element.findNS() ? element.findNS() === this.NS : true) &&
+      (name === 'iq' || name === 'message' || name === 'presence')
+    )
+  }
+
+  isNonza (element) {
+    return !this.isStanza(element)
+  }
+
+  end () {
+    return this.write(this.footer())
+  }
+
+  close () {
+    return new Promise((resolve, reject) => {
+      // TODO timeout
+      const handler = () => {
+        this.socket.close()
+        this.once('close', resolve)
+      }
+      this.parser.once('end', handler)
+    })
+  }
+
+  use (plugin) {
+    if (this.plugins.includes(plugin)) return
+    this.plugins.push(plugin)
+    plugin(this)
+  }
+
+  // override
+  waitHeader () {}
+  header () {}
+  footer () {}
+  match () {}
+}
+
+// overrirde
+Connection.prototype.NS = ''
+Connection.prototype.Socket = null
+Connection.prototype.Parser = StreamParser
+
+module.exports = Connection
+module.exports.getHostname = getHostname

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@xmpp/connection",
+  "description": "XMPP connection for JavaScript",
+  "repository": "github:node-xmpp/node-xmpp",
+  "homepage": "https://github.com/node-xmpp/node-xmpp/tree/master/packages/connection",
+  "bugs": "http://github.com/node-xmpp/node-xmpp/issues",
+  "version": "0.0.0",
+  "license": "ISC",
+  "keywords": [
+    "XMPP",
+    "connection"
+  ],
+  "dependencies": {
+    "@xmpp/jid": "^0.0.1",
+    "@xmpp/streamparser": "^0.0.1"
+  },
+  "devDependencies": {
+    "@xmpp/xml": "^0.0.1"
+  },
+  "browser": {
+    "url": false
+  }
+}

--- a/test/ava/component.js
+++ b/test/ava/component.js
@@ -1,0 +1,43 @@
+const test = require('ava')
+const Component = require('../../packages/component')
+const JID = require('../../packages/jid')
+
+test('component', t => {
+  t.plan(11)
+
+  const component = new Component()
+
+  component.on('connect', () => {
+    t.pass('socket open')
+  })
+
+  component.on('open', ({name, attrs}) => {
+    t.is(name, 'stream:stream')
+    t.is(attrs['xml:lang'], 'en')
+    t.is(attrs.from, 'component.localhost')
+    t.is(typeof attrs.id, 'string')
+    t.is(attrs.xmlns, 'jabber:component:accept')
+  })
+
+  component.on('authenticate', auth => {
+    t.is(typeof auth, 'function')
+    auth('mysecretcomponentpassword')
+  })
+
+  component.on('ready', () => {
+    t.pass('ready')
+  })
+
+  component.on('online', (jid) => {
+    t.true(jid instanceof JID.JID)
+    t.is(jid.toString(), 'component.localhost')
+  })
+
+  return component.start('xmpp:component.localhost:5347')
+    .then((jid) => {
+      t.is(jid.toString(), 'component.localhost')
+    })
+    .catch(reason => {
+      console.log(reason)
+    })
+})


### PR DESCRIPTION
brand new `@xmpp/component` modular package

Adds the following packages
- `@xmpp/connection`
- `@xmpp/connection-tcp`
- `@xmpp/component`

The goal is to reuse those for client/server as it's already done in https://github.com/node-xmpp/node-xmpp/pull/309

Todo
- now
  - tests
  - doc
  - fix `FIXME`s and `TODO`s
- later
  - `@xmpp/component-core`
  - `@xmpp/reconnect`
  - `@xmpp/component-connection` [XEP-0225](https://xmpp.org/extensions/xep-0225.html)
  - `@xmpp/component-protocol` [XEP-0114](https://xmpp.org/extensions/xep-0114.html)

and  have `@xmpp/component` use them. Or maybe just files.

Please comment on the API as it would be the same for client and server.

``` javascript
'use strict'

const Component = require('@xmpp/component')
const entity = new Component()

// emitted for any error
entity.once('error', (err) => {
  console.log('error', err)
})

// emitted for incoming stanza _only_ (iq/presence/message) qualified with the right namespace
entity.on('stanza', (stanza) => {
  console.log('stanza', stanza.toString())
})

// emitted for incoming nonza _only_
entity.on('nonza', (nonza) => {
  console.log('nonza', nonza.toString())
})

// emitted for any in our out XML fragment
entity.on('fragment', (output, input) => {
  console.log(output ? '=>' : '<=', (output || input).trim())
})

// "start" opens the socket and the XML stream
entity.start('xmpp:component.localhost:5347')
  // resolves once online
  .then((jid) => {
    console.log('started', jid.toString())
  })
  // rejects for any error before online
  .catch(err => {
    console.error(err)
  })

// emitted when the socket is open
entity.on('connect', () => {
  console.log('connected')
})

// emitted when the XMPP stream has open and we received the server stream
entity.on('open', (el) => {
  console.log('open')
})

// emitted when authentication is required
entity.on('authenticate', authenticate => {
  authenticate('foobar')
    .then(() => {
      console.log('authenticated')
    })
    .catch((err) => {
      console.error('authentication failed', err)
    })
})

// emitted when the XMPP entity is ready and has a jid
entity.on('online', (jid) => {
  console.log('online', jid.toString())
})

process.on('unhandledRejection', function (reason, p) {
  console.log('Possibly Unhandled Rejection at: Promise ', p, ' reason: ', reason)
})
```

Here is an example with async/await

``` javascript
const jid = await entity.start('xmpp:component.localhost:5347')
entity.send(...)
```
