### PR TITLE
stop using standard ports for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "files": [
       "packages/*/ava/**/*.js"
     ]
+  },
+  "dependencies": {
+    "babel-polyfill": "^6.16.0"
   }
 }

--- a/packages/node-xmpp-client/lib/session.js
+++ b/packages/node-xmpp-client/lib/session.js
@@ -48,7 +48,7 @@ Session.prototype._setupSocketConnection = function (opts) {
   this.connection = new Connection(params)
   this._addConnectionListeners()
 
-  if (opts.host) {
+  if (opts.host || opts.port) {
     this._socketConnectionToHost(opts)
   } else if (!SRV) {
     throw new Error('Cannot load SRV')
@@ -66,7 +66,7 @@ Session.prototype._socketConnectionToHost = function (opts) {
       socket: function () {
         return tls.connect(
           opts.port || 5223,
-          opts.host,
+          opts.host || 'localhost',
           opts.credentials || {},
           function () {
             if (this.socket.authorized) {

--- a/packages/node-xmpp-client/test/reconnect.js
+++ b/packages/node-xmpp-client/test/reconnect.js
@@ -14,7 +14,7 @@ var user = {
 function startServer (done) {
   // Sets up the server.
   var c2s = new C2SServer({
-    port: 5222,
+    port: 5225,
     domain: 'localhost'
   })
 
@@ -81,7 +81,8 @@ describe.skip('Reconnect', function () {
       var cl = new Client({
         jid: user.jid,
         password: user.password,
-        reconnect: true
+        reconnect: true,
+        port: 5225
       })
       var eventChain = createChain(cl)
 
@@ -118,7 +119,8 @@ describe.skip('Reconnect', function () {
         password: user.password,
         reconnect: true,
         initialReconnectDelay: 10,
-        maxReconnectDelay: 11
+        maxReconnectDelay: 11,
+        port: 5225
       })
       var eventChain = createChain(cl)
 

--- a/packages/node-xmpp-client/test/sasl.js
+++ b/packages/node-xmpp-client/test/sasl.js
@@ -41,7 +41,7 @@ var user = {
 function startServer (mechanism, done) {
   // Sets up the server.
   var c2s = new C2SServer({
-    port: 5222,
+    port: 5225,
     domain: 'localhost',
     autostart: false
   })
@@ -122,6 +122,7 @@ function startServer (mechanism, done) {
 }
 
 function createClient (opts) {
+  opts.port = 5225
   var cl = new Client(opts)
 
   cl.on('stanza', function (stanza) {
@@ -159,7 +160,8 @@ describe('SASL', function () {
       var cl = createClient({
         jid: user.jid,
         password: user.password,
-        preferred: Plain.id
+        preferred: Plain.id,
+        port: 5225
       })
 
       cl.on('online', function () {
@@ -237,7 +239,8 @@ describe('SASL', function () {
       var cl = createClient({
         jid: user.jid,
         password: user.password,
-        preferred: 'DIGEST-MD5'
+        preferred: 'DIGEST-MD5',
+        port: 5225
       })
 
       cl.on('online', function () {

--- a/packages/node-xmpp-client/test/stream.js
+++ b/packages/node-xmpp-client/test/stream.js
@@ -8,7 +8,7 @@ var ltx = Client.ltx
 require('should')
 
 describe('Authentication', function () {
-  var C2S_PORT = 5222
+  var C2S_PORT = 5225
   var onSocket = function () {}
   var duringafter = false
   var server = null
@@ -34,8 +34,8 @@ describe('Authentication', function () {
     var options = {
       jid: 'test@localhost',
       password: 'test',
-      host: 'localhost',
-      port: C2S_PORT
+      port: C2S_PORT,
+      host: 'localhost'
     }
     onSocket = function (socket) {
       socket.once('data', function (d) {

--- a/packages/node-xmpp-server/test/integration/C2S/BOSH.js
+++ b/packages/node-xmpp-server/test/integration/C2S/BOSH.js
@@ -7,7 +7,8 @@ var Server = XMPP.C2S.BOSHServer
 var Client = require('node-xmpp-client')
 
 var server = new Server({
-  autostart: false
+  autostart: false,
+  port: 5285
 })
 server.on('connection', function (connection) {
   connection.on('authenticate', function (opts, cb) {
@@ -36,7 +37,7 @@ describe('C2S BOSH server client', function () {
         jid: 'foo@localhost',
         password: 'password',
         bosh: {
-          url: 'http://localhost:5280/http-bind'
+          url: 'http://localhost:5285/http-bind'
         }
       })
       client.once('error', done)

--- a/packages/node-xmpp-server/test/integration/C2S/TCP.js
+++ b/packages/node-xmpp-server/test/integration/C2S/TCP.js
@@ -7,7 +7,8 @@ var Server = XMPP.C2S.TCPServer
 var Client = require('node-xmpp-client')
 
 var server = new Server({
-  autostart: false
+  autostart: false,
+  port: 5225
 })
 server.on('connection', function (connection) {
   connection.on('authenticate', function (opts, cb) {
@@ -34,7 +35,8 @@ describe('C2S TCP server client', function () {
     it('should connect', function (done) {
       client = new Client({
         jid: 'foo@localhost',
-        password: 'password'
+        password: 'password',
+        port: 5225
       })
       client.on('error', done)
       client.on('online', function () {

--- a/packages/node-xmpp-server/test/integration/C2S/authentication.js
+++ b/packages/node-xmpp-server/test/integration/C2S/authentication.js
@@ -23,7 +23,7 @@ var user = {
 function startServer (mechanism) {
   // Sets up the server.
   var c2s = new Server({
-    port: 5222,
+    port: 5225,
     domain: 'localhost'
   })
 
@@ -91,6 +91,7 @@ function startServer (mechanism) {
 }
 
 function createClient (opts) {
+  opts.port = 5225
   var cl = new Client(opts)
 
   cl.on('stanza', function (stanza) {

--- a/packages/node-xmpp-server/test/integration/C2S/bind.js
+++ b/packages/node-xmpp-server/test/integration/C2S/bind.js
@@ -8,7 +8,7 @@ var Plain = XMPP.auth.Plain
 var JID = XMPP.JID
 var Client = require('node-xmpp-client')
 
-var port = 5222
+var port = 5225
 var user = {
   jid: new JID('me@localhost/res'),
   password: 'secret'

--- a/packages/node-xmpp-server/test/integration/S2S/Router.js
+++ b/packages/node-xmpp-server/test/integration/S2S/Router.js
@@ -25,13 +25,13 @@ describe('S2S Router Integration', function () {
       .withArgs('_xmpp-server._tcp.nodexmpp.com').yields(null, [{
         priority: 10,
         weight: 5,
-        port: 5270,
+        port: 5271,
         name: 'localhost'
       }])
       .withArgs('_xmpp-server._tcp.example.com').yields(null, [{
         priority: 10,
         weight: 5,
-        port: 5269,
+        port: 5272,
         name: 'localhost'
       }])
 
@@ -65,8 +65,8 @@ describe('S2S Router Integration', function () {
   }
 
   beforeEach(function () {
-    exampleRouter = new Router(5269, 'localhost')
-    nodeXmppRouter = new Router(5270, 'localhost')
+    exampleRouter = new Router(5272, 'localhost')
+    nodeXmppRouter = new Router(5271, 'localhost')
   })
 
   afterEach(function (done) {

--- a/packages/node-xmpp-server/test/integration/component.js
+++ b/packages/node-xmpp-server/test/integration/component.js
@@ -8,7 +8,8 @@ var Server = XMPP.component.Server
 var Component = require('node-xmpp-component')
 
 var server = new Server({
-  autostart: false
+  autostart: false,
+  port: 5343
 })
 server.on('connection', function (connection) {
   connection.on('verify-component', function (jid, cb) {
@@ -41,7 +42,7 @@ describe('component server - component', function () {
         jid: 'foo.localhost',
         password: 'password',
         host: 'localhost',
-        port: 5347
+        port: 5343
       })
       component.on('error', done)
       component.on('online', done)
@@ -54,7 +55,7 @@ describe('component server - component', function () {
         jid: 'unknown.localhost',
         password: 'password',
         host: 'localhost',
-        port: 5347
+        port: 5343
       })
       component.on('error', done)
       component.on('disconnect', function (err) {
@@ -71,7 +72,7 @@ describe('component server - component', function () {
         jid: 'foo.localhost',
         password: 'notthepassword',
         host: 'localhost',
-        port: 5347
+        port: 5343
       })
       component.on('error', done)
       component.on('disconnect', function (err) {
@@ -98,7 +99,7 @@ describe('component server - component', function () {
         jid: 'foo.localhost',
         password: 'password',
         host: 'localhost',
-        port: 5347
+        port: 5343
       })
       component.on('error', done)
       component.on('disconnect', function (err) {

--- a/packages/node-xmpp/test/server-event-test.js
+++ b/packages/node-xmpp/test/server-event-test.js
@@ -11,7 +11,7 @@ var c2s = null
 function startServer () {
   // Sets up the server.
   c2s = new xmpp.server.C2S.TCPServer({
-    port: 5222,
+    port: 5225,
     domain: 'localhost'
   })
 
@@ -82,7 +82,8 @@ describe.skip('C2Server', function () {
       cl = new xmpp.Client({
         jid: 'bob@example.com',
         password: 'alice',
-        host: 'localhost'
+        host: 'localhost',
+        port: 5225
       })
       cl.on('online', function () {
         eventChain.push('clientonline')

--- a/packages/streamparser/index.js
+++ b/packages/streamparser/index.js
@@ -29,6 +29,10 @@ function StreamParser (options) {
   this.bytesParsedOnStanzaBegin = 0
 
   this.parser.on('startElement', function (name, attrs) {
+    if (!self.element) {
+      self.emit('startElement', name, attrs)
+    }
+
     // TODO: refuse anything but <stream:stream>
     if (!self.element && (name === 'stream:stream')) {
       self.emit('streamStart', attrs)
@@ -49,14 +53,19 @@ function StreamParser (options) {
   })
 
   this.parser.on('endElement', function (name) {
+    if (!self.element) {
+      self.emit('endElement', name)
+    }
+
     if (!self.element && (name === 'stream:stream')) {
       self.end()
     } else if (self.element && (name === self.element.name)) {
       if (self.element.parent) {
         self.element = self.element.parent
       } else {
-        /* Stanza complete */
-        self.emit('stanza', self.element)
+        /* element complete */
+        self.emit('element', self.element)
+        self.emit('stanza', self.element) // FIXME deprecate
         delete self.element
         /* maxStanzaSize doesn't apply until next startElement */
         delete self.bytesParsedOnStanzaBegin

--- a/packages/xml/index.js
+++ b/packages/xml/index.js
@@ -2,25 +2,18 @@
 
 var ltx = require('ltx')
 
-module.exports.IQ = require('./lib/IQ')
-module.exports.Message = require('./lib/Message')
-module.exports.Presence = require('./lib/Presence')
+var exports = module.exports = ltx.tag
 
-module.exports.Stanza = require('./lib/Stanza')
-module.exports.createStanza = require('./lib/createStanza')
+Object.assign(exports, ltx)
 
-module.exports.parse = require('./lib/parse')
-module.exports.Parser = require('./lib/Parser')
+exports.IQ = require('./lib/IQ')
+exports.Message = require('./lib/Message')
+exports.Presence = require('./lib/Presence')
 
-module.exports.Element = ltx.Element
-module.exports.createElement = ltx.createElement
+exports.Stanza = require('./lib/Stanza')
+exports.createStanza = require('./lib/createStanza')
 
-module.exports.escapeXML = ltx.escapeXML
-module.exports.escapeXMLText = ltx.escapeXMLText
+exports.parse = require('./lib/parse')
+exports.Parser = require('./lib/Parser')
 
-module.exports.equal = ltx.equal
-module.exports.nameEqual = ltx.nameEqual
-module.exports.attrsEqual = ltx.attrsEqual
-module.exports.childrenEqual = ltx.childrenEqual
-
-module.exports.ltx = ltx
+exports.ltx = ltx

--- a/packages/xml/lib/createStanza.js
+++ b/packages/xml/lib/createStanza.js
@@ -7,7 +7,7 @@ var Element = require('ltx').Element
  * JSX compatible API, use this function as pragma
  * https://facebook.github.io/jsx/
  * Returns a Stanza if name is presence, message or iq an ltx Element otherwise.
- *a
+ *
  * @param  {string} name  name of the element
  * @param  {object} attrs object of attribute key/value pairs
  * @return {Element}      Stanza or Element

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <script src="../../node_modules/babel-polyfill/dist/polyfill.js"></script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/should/should.js"></script>
     <script>


### PR DESCRIPTION
* allow to set port without hostname on `node-xmpp-client` configuration (defaults to localhost)
* stop using standard ports for tests
* add more events to streamparser
* smarter `@xmpp/xml` package