### PR TITLE
Stop leaking ltx.tag for possible mutation.

### DIFF
--- a/packages/node-xmpp-server/test/unit/S2S/Router.js
+++ b/packages/node-xmpp-server/test/unit/S2S/Router.js
@@ -70,7 +70,7 @@ describe('S2S Router', function () {
       'from': 'example.com',
       'to': 'nodexmpp.com',
       'version': '1.0',
-    'xmlns': 'jabber:server'}
+      'xmlns': 'jabber:server'}
 
     it('should not offer TLS to incoming connections without credentials', function () {
       var router = new Router()

--- a/packages/node-xmpp-server/test/unit/S2S/incoming.js
+++ b/packages/node-xmpp-server/test/unit/S2S/incoming.js
@@ -167,18 +167,21 @@ describe('S2S IncomingServer', function () {
 
       server.socket = {
         getPeerCertificate: sinon.stub().returns(
-          { subject: {
-            C: 'US',
-            ST: 'NC',
-            L: 'Raleigh',
-            O: 'Example.com',
-            CN: 'example.com'
-          },
-          issuer: { C: 'US',
-            ST: 'NC',
-            L: 'Durham',
-            O: 'Realtime',
-          CN: '*.nodexmpp.com' }
+          {
+            subject: {
+              C: 'US',
+              ST: 'NC',
+              L: 'Raleigh',
+              O: 'Example.com',
+              CN: 'example.com'
+            },
+            issuer: {
+              C: 'US',
+              ST: 'NC',
+              L: 'Durham',
+              O: 'Realtime',
+              CN: '*.nodexmpp.com'
+            }
           }),
         renegotiate: sinon.stub().yields(null)
       }

--- a/packages/xml/index.js
+++ b/packages/xml/index.js
@@ -2,7 +2,7 @@
 
 var ltx = require('ltx')
 
-var exports = module.exports = ltx.tag
+var exports = module.exports = ltx.tag.bind(null)
 
 Object.assign(exports, ltx)
 

--- a/packages/xml/test/index.js
+++ b/packages/xml/test/index.js
@@ -1,0 +1,25 @@
+/* global describe, it, beforeEach */
+
+'use strict'
+
+var assert = require('assert')
+
+describe('index', function () {
+  var xml, ltx
+
+  beforeEach(function () {
+    xml = ltx = null
+    delete require.cache[require.resolve('ltx')]
+    delete require.cache[require.resolve('../index')]
+  })
+
+  it('does not leak ltx.tag for accidental mutation', function () {
+    ltx = require('ltx')
+    var keysBefore = Object.keys(ltx.tag)
+
+    xml = require('../index')
+    xml.foo = 'bar'
+    var keysAfter = Object.keys(ltx.tag)
+    assert(keysBefore.toString() === keysAfter.toString())
+  })
+})


### PR DESCRIPTION
The recent publish broke us. This fix resolves our issues.

In our usage (which could be a bit non-standard), `ltx.parse` seems to somehow be pointing to `xml/lib/parse.js` instead of `ltx/lib/parse.js`. This fix results in it pointing to the correct parse function in our test suite. Admittedly, it does seem odd that exposing `ltx.tag` would somehow end up with the wrong parse function being used. But, not exposing something like this seems like a safer thing to do regardless.
