### PR TITLE
console: enable NODE_NO_READLINE env var

### DIFF
--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -14,17 +14,13 @@ npm install -g @xmpp/console
 
 ## Use
 
-Component
+###### Component
+
 ```
 xmpp-console xmpp:component.localhost:5347 password
 ```
 
-Client
+###### Client
 ```
-xmpp-console xmpp:user@locacalhost password
-```
-
-Client with resource
-```
-xmpp-console xmpp:user@locacalhost/terminal password
+xmpp-console xmpp:user@locacalhost[/resource] password
 ```

--- a/packages/console/app.js
+++ b/packages/console/app.js
@@ -34,11 +34,16 @@ function send (line) {
   entity.send(el)
 }
 
-const rl = readline.createInterface({
+const options = {
   input: process.stdin,
   output: process.stdout,
   prompt: chalk.magenta.bold('✏ ')
-})
+}
+if (parseInt(process.env.NODE_NO_READLINE)) {
+  options.terminal = false;
+}
+
+const rl = readline.createInterface(options)
 
 rl.prompt(true)
 


### PR DESCRIPTION
Allow to use `xmpp-console` with `rlwrap` to enable persistent history.

Unfortunately it shows some bugs so it's not ready to be advertised yet. Also I'd prefer to have the persistent history functionality included in xmpp-console but it's not trivial as Node.js readline module doesn't allow to do that easily.

See https://github.com/nodejs/node/blob/db1087c9757c31a82c50a1eba368d8cba95b57d0/lib/internal/repl.js for inspiration.

 Here is the documentation I wrote for the `README.md`.

## Persistent history

Just [like Node.js REPL](https://nodejs.org/api/repl.html#repl_using_the_node_js_repl_with_advanced_line_editors) it is possible to use xmpp-console with `rlwrap` to enable advanced line-editors.

```
env NODE_NO_READLINE=1 rlwrap xmpp-console xmpp:component.localhost:5347 password
```