### PR TITLE
Fixed WebSocket stream closing

### DIFF
--- a/packages/plugins/websocket/lib/Connection.js
+++ b/packages/plugins/websocket/lib/Connection.js
@@ -15,7 +15,7 @@ const NS_FRAMING = 'urn:ietf:params:xml:ns:xmpp-framing'
 class ConnectionWebSocket extends Connection {
   // https://tools.ietf.org/html/rfc7395#section-3.6
   footer () {
-    return xml.Element('close', {
+    return new xml.Element('close', {
       xmlns: NS_FRAMING,
     })
   }


### PR DESCRIPTION
`xml.Element` is a constructor and needs to be called with `new`