### PR TITLE
Fix xml/parse

### DIFF
--- a/packages/xml/lib/parse.js
+++ b/packages/xml/lib/parse.js
@@ -3,5 +3,5 @@
 const tag = require('./tag')
 
 module.exports = function parse(str) {
-  return tag([str], [])
+  return tag([str])
 }


### PR DESCRIPTION
`tag()` expects substitutions as subsequent arguments, not in Array