### PR TITLE
[WIP] connection status and events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: node_js
 node_js:
   - '6'
   - '7'
+  - '8'
 
 cache:
   yarn: true

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,6 @@ stop:
 
 restart:
 	./server/ctl restart
+
+size:
+	browserify packages/client-core/index.js | babili | gzip > /tmp/bundle.js.gz ; stat -c%s /tmp/bundle.js.gz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"private": true,
+  "private": true,
   "devDependencies": {
     "ava": "^0.19.1",
     "babel-cli": "^6.24.1",
@@ -25,5 +25,6 @@
       "packages/**/test.js",
       "packages/**/test/*.js"
     ]
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,5 @@
       "packages/**/test.js",
       "packages/**/test/*.js"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -55,11 +55,6 @@ entity.start('localhost') // Auto
 // entity.start('xmpps://localhost:5223') // TLS
 // entity.start('ws://localhost:5280/xmpp-websocket') // Websocket
 // entity.start('wss://localhost:5281/xmpp-websocket') // Secure WebSocket
-  // Resolves once online
-  .then(jid => {
-    console.log('jid', jid.toString())
-  })
-  // Rejects for any error before online
   .catch(err => {
     console.error('start failed', err)
   })

--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -43,8 +43,8 @@ entity.on('output', data => console.log('⮊ OUT', data))
 //   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
 // })
 
-// Resolves if or when ready (online)
-entity.ready().then(jid => {
+// Runs if online and when online
+entity.ready(jid => {
   console.log('jid', jid.toString())
   entity.send(xml`<presence/>`)
 })

--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -13,8 +13,8 @@ entity.on('error', err => {
 })
 
 // Let's log status changes
-function logStatus(status, ...args) {
-  console.log(status, ...args)
+function logStatus(status) {
+  console.log('🛈', status)
 }
 logStatus(entity.status)
 entity.on('status', (status, ...args) => {
@@ -33,9 +33,9 @@ entity.on('status', (status, ...args) => {
 
 // useful for logging raw traffic
 // Emitted for every incoming fragment
-entity.on('input', data => console.log('⮈ IN ', data))
+entity.on('input', data => console.log('⮈', data))
 // Emitted for every outgoing fragment
-entity.on('output', data => console.log('⮊ OUT', data))
+entity.on('output', data => console.log('⮊', data))
 
 // Emitted for any in our out XML root element
 // useful for logging

--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -13,12 +13,8 @@ entity.on('error', err => {
 })
 
 // Let's log status changes
-function logStatus(status) {
+entity.listen('status', status => {
   console.log('🛈', status)
-}
-logStatus(entity.status)
-entity.on('status', (status, ...args) => {
-  logStatus(status, ...args)
 })
 
 // Emitted for incoming stanza _only_ (iq/presence/message) qualified with the right namespace
@@ -33,9 +29,9 @@ entity.on('status', (status, ...args) => {
 
 // useful for logging raw traffic
 // Emitted for every incoming fragment
-entity.on('input', data => console.log('⮈', data))
+entity.listen('input', data => console.log('⮈', data))
 // Emitted for every outgoing fragment
-entity.on('output', data => console.log('⮊', data))
+entity.listen('output', data => console.log('⮊', data))
 
 // Emitted for any in our out XML root element
 // useful for logging
@@ -43,8 +39,11 @@ entity.on('output', data => console.log('⮊', data))
 //   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
 // })
 
-// Runs if online and when online
-entity.ready(jid => {
+// entity.on('online', jid => {
+//   console.log('jid', jid.toString())
+//   entity.send(xml`<presence/>`)
+// })
+entity.listen('online', jid => {
   console.log('jid', jid.toString())
   entity.send(xml`<presence/>`)
 })
@@ -60,7 +59,7 @@ entity.start('localhost') // Auto
   })
 
 // Emitted when authentication is required
-entity.on('authenticate', authenticate => {
+entity.listen('authenticate', authenticate => {
   authenticate('node-xmpp', 'foobar').catch(err => console.error('authentication failed', err))
 })
 

--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -4,7 +4,7 @@
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
-const {client, xml} = require('./index') // For you; require('@xmpp/client')
+const {xml, client} = require('./index') // For you; require('@xmpp/client')
 const entity = client()
 
 // Emitted for any error
@@ -12,8 +12,13 @@ entity.on('error', err => {
   console.error('error', err)
 })
 
-entity.on('close', () => {
-  console.log('closed')
+// Let's log status changes
+function logStatus(status, ...args) {
+  console.log(status, ...args)
+}
+logStatus(entity.status)
+entity.on('status', (status, ...args) => {
+  logStatus(status, ...args)
 })
 
 // Emitted for incoming stanza _only_ (iq/presence/message) qualified with the right namespace
@@ -38,30 +43,10 @@ entity.on('output', data => console.log('⮊ OUT', data))
 //   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
 // })
 
-// Emitted when the connection is established
-entity.on('connect', () => {
-  console.log('1. connected')
-})
-
-// Emitted when the XMPP stream has open and we received the server stream
-entity.on('open', () => {
-  console.log('2. open')
-})
-
-// Emitted when the XMPP entity is authenticated
-entity.on('authenticated', () => {
-  console.log('3. authenticated')
-})
-
-// Emitted when authenticated and bound
-entity.on('online', jid => {
-  console.log('4. online', jid.toString())
-
-  entity.send(xml`
-    <iq id='ping' type='get'>
-      <ping xmlns='urn:xmpp:ping'/>
-    </iq>
-  `)
+// Resolves if or when ready (online)
+entity.ready().then(jid => {
+  console.log('jid', jid.toString())
+  entity.send(xml`<presence/>`)
 })
 
 // "start" opens the socket and the XML stream
@@ -70,9 +55,9 @@ entity.start('localhost') // Auto
 // entity.start('xmpps://localhost:5223') // TLS
 // entity.start('ws://localhost:5280/xmpp-websocket') // Websocket
 // entity.start('wss://localhost:5281/xmpp-websocket') // Secure WebSocket
-  // resolves once online
+  // Resolves once online
   .then(jid => {
-    console.log('started', jid.toString())
+    console.log('jid', jid.toString())
   })
   // Rejects for any error before online
   .catch(err => {
@@ -81,13 +66,7 @@ entity.start('localhost') // Auto
 
 // Emitted when authentication is required
 entity.on('authenticate', authenticate => {
-  authenticate('node-xmpp', 'foobar')
-    .then(() => {
-      console.log('authenticated')
-    })
-    .catch(err => {
-      console.error('authentication failed', err)
-    })
+  authenticate('node-xmpp', 'foobar').catch(err => console.error('authentication failed', err))
 })
 
 process.on('unhandledRejection', (reason, p) => {

--- a/packages/client/lib/Client.js
+++ b/packages/client/lib/Client.js
@@ -13,19 +13,6 @@ class Client extends ClientCore {
       } // Browserify stub
       this.plugin(plugin)
     })
-
-    // So that we have a common inteface with component
-    const {sasl} = this.plugins
-    sasl.handleMechanism = (mech, features) => new Promise((resolve, reject) => {
-      this._status('authenticate', (username, password) => {
-        return sasl.authenticate(mech, {username, password}, features)
-        .then(resolve)
-        .catch(err => {
-          reject(err)
-          throw err
-        })
-      })
-    })
   }
 }
 

--- a/packages/client/lib/Client.js
+++ b/packages/client/lib/Client.js
@@ -17,7 +17,7 @@ class Client extends ClientCore {
     // So that we have a common inteface with component
     const {sasl} = this.plugins
     sasl.handleMechanism = (mech, features) => new Promise((resolve, reject) => {
-      this.emit('authenticate', (username, password) => {
+      this._status('authenticate', (username, password) => {
         return sasl.authenticate(mech, {username, password}, features)
         .then(resolve)
         .catch(err => {

--- a/packages/component-core/index.js
+++ b/packages/component-core/index.js
@@ -38,23 +38,22 @@ class Component extends Connection {
   // https://xmpp.org/extensions/xep-0114.html#example-3
   open(...args) {
     return super.open(...args).then(el => {
-      this.emit('authenticate', secret => {
-        return this.authenticate(el.attrs.id, secret)
-      })
+      this._status('authenticate', secret => this.authenticate(el.attrs.id, secret))
     })
   }
 
   // https://xmpp.org/extensions/xep-0114.html#example-3
   authenticate(id, password) {
+    this._status('authenticating')
     const hash = crypto.createHash('sha1')
     hash.update(id + password, 'binary')
     return this.sendReceive(xml`<handshake>${hash.digest('hex')}</handshake>`).then(el => {
       if (el.name !== 'handshake') {
         throw new Error('unexpected stanza')
       }
-      this._authenticated()
+      this._status('authenticated')
       this._jid(this.domain)
-      this._online()
+      this._status('online', this.jid)
     })
   }
 }

--- a/packages/component/example.js
+++ b/packages/component/example.js
@@ -43,8 +43,7 @@ entity.on('output', data => console.log('⮊ OUT', data))
 //   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
 // })
 
-// Runs if online and when online
-entity.ready(jid => {
+entity.on('online', jid => {
   console.log('jid', jid.toString())
   entity.send(xml`<presence/>`)
 })

--- a/packages/component/example.js
+++ b/packages/component/example.js
@@ -43,19 +43,14 @@ entity.on('output', data => console.log('⮊ OUT', data))
 //   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
 // })
 
-// Resolves if or when online
-entity.ready().then(jid => {
+// Runs if online and when online
+entity.ready(jid => {
   console.log('jid', jid.toString())
   entity.send(xml`<presence/>`)
 })
 
 // "start" opens the socket and the XML stream
 entity.start({uri: 'xmpp://localhost:5347', domain: 'node-xmpp.localhost'})
-  // Resolves once online
-  .then(jid => {
-    console.log('jid', jid.toString())
-  })
-  // Rejects for any error before online
   .catch(err => {
     console.error('start failed', err)
   })

--- a/packages/component/example.js
+++ b/packages/component/example.js
@@ -13,8 +13,8 @@ entity.on('error', err => {
 })
 
 // Let's log status changes
-function logStatus(status, ...args) {
-  console.log(status, ...args)
+function logStatus(status) {
+  console.log('🛈', status)
 }
 logStatus(entity.status)
 entity.on('status', (status, ...args) => {

--- a/packages/component/example.js
+++ b/packages/component/example.js
@@ -8,42 +8,34 @@ const {xml, component} = require('.') // For you require('@xmpp/component')
 const entity = component()
 
 // Emitted for any error
-entity.on('error', err => {
+entity.listen('error', err => {
   console.error('error', err)
 })
 
-// Let's log status changes
-function logStatus(status) {
+// Let's log status
+entity.listen('status', status => {
   console.log('🛈', status)
-}
-logStatus(entity.status)
-entity.on('status', (status, ...args) => {
-  logStatus(status, ...args)
 })
 
 // Emitted for incoming stanza _only_ (iq/presence/message) qualified with the right namespace
-// entity.on('stanza', (stanza) => {
-//   console.log('stanza', stanza.toString())
-// })
+// entity.listen('stanza', stanza => console.log('stanza', stanza.toString()))
 
 // Emitted for incoming nonza _only_
-// entity.on('nonza', (nonza) => {
-//   console.log('nonza', nonza.toString())
-// })
+// entity.listen('nonza', nonza => console.log('nonza', nonza.toString()))
 
 // useful for logging raw traffic
 // Emitted for every incoming fragment
-entity.on('input', data => console.log('⮈ IN ', data))
+entity.listen('input', data => console.log('⮈ IN ', data))
 // Emitted for every outgoing fragment
-entity.on('output', data => console.log('⮊ OUT', data))
+entity.listen('output', data => console.log('⮊ OUT', data))
 
-// Emitted for any in our out XML root element
-// useful for logging
-// entity.on('element', (input, output) => {
-//   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
-// })
+// Emitted for incoming stanza and nonza
+// entity.listen('element', element => console.log(element.toString)))
 
-entity.on('online', jid => {
+// Emitted for outgoing stanza and nonza
+// entity.listen('send', element => console.log(element.toString)))
+
+entity.listen('online', jid => {
   console.log('jid', jid.toString())
   entity.send(xml`<presence/>`)
 })
@@ -55,7 +47,7 @@ entity.start({uri: 'xmpp://localhost:5347', domain: 'node-xmpp.localhost'})
   })
 
 // Emitted when authentication is required
-entity.on('authenticate', authenticate => {
+entity.listen('authenticate', authenticate => {
   authenticate('foobar').catch(err => console.error('authentication failed', err))
 })
 

--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -131,7 +131,7 @@ class Connection extends EventEmitter {
     }
 
     return Promise.all([
-      this.once('online'),
+      this.promise('online'),
       this.connect(options.uri).then(() => {
         const {domain, lang} = options
         return this.open({domain, lang})
@@ -236,9 +236,8 @@ class Connection extends EventEmitter {
   ready(fn) {
     if (this.status === 'online') {
       fn(this.jid)
-    } else {
-      this.on('online', fn)
     }
+    return this.listen('online', fn)
   }
 
   /**

--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -4,14 +4,12 @@ module.exports = function debug(entity) {
   if (process.env.XMPP_DEBUG) {
     entity.on('input', data => console.log('⮈ IN ', data))
     entity.on('output', data => console.log('⮊ OUT', data))
-    ;['connect', 'open', 'authenticated', 'online', 'error', 'authenticate'].forEach(event => {
-      entity.on(event, arg => {
-        if (arg === undefined || arg === null || typeof arg === 'function') {
-          console.log('🛈    ', event)
-        } else {
-          console.log('🛈    ', event, arg.toString())
-        }
-      })
+    entity.on('status', (status, value) => {
+      if (value === undefined || value === null || typeof value === 'function') {
+        console.log('🛈    ', status)
+      } else {
+        console.log('🛈    ', status, value.toString())
+      }
     })
   }
 }

--- a/packages/events/index.js
+++ b/packages/events/index.js
@@ -36,6 +36,9 @@ class EventEmitter {
     }
   }
   once(event, listener) {
+    if (!listener) {
+      return this.promise(event)
+    }
     const expire = (...args) => {
       listener(...args)
       this.removeListener(event, expire)

--- a/packages/events/index.js
+++ b/packages/events/index.js
@@ -5,7 +5,10 @@ const timeout = require('./lib/timeout')
 const delay = require('./lib/delay')
 const TimeoutError = require('./lib/TimeoutError')
 const promise = require('./lib/promise')
+const EventEmitter = require('./lib/EventEmitter')
 
+exports = module.exports = EventEmitter
+exports.EventEmitter = EventEmitter
 exports.promisify = promisify
 exports.timeout = timeout
 exports.delay = delay

--- a/packages/events/index.js
+++ b/packages/events/index.js
@@ -1,14 +1,11 @@
 'use strict'
 
-const EventEmitter = require('./lib/EventEmitter')
 const promisify = require('./lib/promisify')
 const timeout = require('./lib/timeout')
 const delay = require('./lib/delay')
 const TimeoutError = require('./lib/TimeoutError')
 const promise = require('./lib/promise')
 
-exports = module.exports = EventEmitter
-exports.EventEmitter = EventEmitter
 exports.promisify = promisify
 exports.timeout = timeout
 exports.delay = delay

--- a/packages/events/index.js
+++ b/packages/events/index.js
@@ -1,90 +1,27 @@
 'use strict'
 
-class TimeoutError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'TimeoutError'
-  }
-}
-TimeoutError.prototype.name = 'TimeoutError'
+const EventEmitter = require('./lib/EventEmitter')
+const promisify = require('./lib/promisify')
+const timeout = require('./lib/timeout')
+const delay = require('./lib/delay')
+const TimeoutError = require('./lib/TimeoutError')
+const promise = require('./lib/promise')
 
-class EventEmitter {
-  constructor() {
-    this._listeners = new Map()
-  }
-  on(...args) {
-    this.addListener(...args)
-  }
-  off(...args) {
-    this.removeListener(...args)
-  }
-  addListener(event, listener) {
-    let listeners = this._listeners.get(event)
-    if (!listeners) {
-      listeners = new Set()
-      this._listeners.set(event, listeners)
-    }
-    listeners.add(listener)
-  }
-  removeListener(event, listener) {
-    const listeners = this._listeners.get(event)
-    if (listeners) {
-      listeners.delete(listener)
-      if (listeners.size === 0) {
-        this._listeners.delete(event)
-      }
-    }
-  }
-  once(event, listener) {
-    if (!listener) {
-      return this.promise(event)
-    }
-    const expire = (...args) => {
-      listener(...args)
-      this.removeListener(event, expire)
-    }
-    this.addListener(event, expire)
-  }
-  promise(event, timeout) {
-    return new Promise((resolve, reject) => {
-      let timer
-      const cleanup = () => {
-        this.removeListener(event, onEvent)
-        this.removeListener('error', onError)
-        clearTimeout(timer)
-      }
-      if (typeof timeout === 'number') {
-        timer = setTimeout(() => {
-          reject(new TimeoutError(`"${event}" event didn't fire within ${timeout}ms`))
-          cleanup()
-        }, timeout)
-      }
-      function onError(reason) {
-        reject(reason)
-        cleanup()
-      }
-      function onEvent(value) {
+exports = module.exports = EventEmitter
+exports.EventEmitter = EventEmitter
+exports.promisify = promisify
+exports.timeout = timeout
+exports.delay = delay
+exports.TimeoutError = TimeoutError
+exports.promise = promise
+exports.promify = function promify(obj, method, ...args) {
+  return new Promise((resolve, reject) => {
+    obj[method](...args, (err, value) => {
+      if (err !== null && err !== undefined) {
+        reject(err)
+      } else {
         resolve(value)
-        cleanup()
       }
-      this.once('error', onError)
-      this.once(event, onEvent)
     })
-  }
-  emit(event, arg) {
-    const listeners = this._listeners.get(event)
-    if (listeners) {
-      listeners.forEach(listener => {
-        listener(arg)
-      })
-    } else if (event === 'error') {
-      throw arg instanceof Error ? arg : new Error(arg)
-    }
-  }
-  listenerCount(event) {
-    const listeners = this.listeners.get(event)
-    return listeners ? listeners.size : 0
-  }
+  })
 }
-
-module.exports = EventEmitter

--- a/packages/events/lib/EventEmitter.js
+++ b/packages/events/lib/EventEmitter.js
@@ -1,59 +1,17 @@
 'use strict'
 
-const promise = require('./promise')
+const _EventEmitter = require('events')
 
 class EventEmitter {
   constructor() {
-    this._listeners = new Map()
-  }
-  on(...args) {
-    this.addListener(...args)
-  }
-  off(...args) {
-    this.removeListener(...args)
-  }
-  addListener(event, listener) {
-    let listeners = this._listeners.get(event)
-    if (!listeners) {
-      listeners = new Set()
-      this._listeners.set(event, listeners)
-    }
-    listeners.add(listener)
-  }
-  removeListener(event, listener) {
-    const listeners = this._listeners.get(event)
-    if (listeners) {
-      listeners.delete(listener)
-      if (listeners.size === 0) {
-        this._listeners.delete(event)
-      }
-    }
-  }
-  once(event, listener) {
-    if (!listener) {
-      return promise(this, event)
-    }
-    const expire = (...args) => {
-      listener(...args)
-      this.removeListener(event, expire)
-    }
-    this.addListener(event, expire)
-  }
-  emit(event, ...values) {
-    const listeners = this._listeners.get(event)
-    if (listeners) {
-      listeners.forEach(listener => {
-        listener(...values)
-      })
-    } else if (event === 'error') {
-      const [err] = values
-      throw err instanceof Error ? err : new Error(err)
-    }
-  }
-  listenerCount(event) {
-    const listeners = this._listeners.get(event)
-    return listeners ? listeners.size : 0
+    this._emitter = new _EventEmitter()
   }
 }
+
+['on', 'addListener', 'removeListener', 'once'].forEach(name => {
+  EventEmitter.prototype[name] = function (...args) {
+    this._emitter[name](...args)
+  }
+})
 
 module.exports = EventEmitter

--- a/packages/events/lib/EventEmitter.js
+++ b/packages/events/lib/EventEmitter.js
@@ -1,14 +1,32 @@
 'use strict'
 
 const _EventEmitter = require('events')
+const promise = require('./promise')
 
 class EventEmitter {
   constructor() {
     this._emitter = new _EventEmitter()
+    this._state = null
+  }
+
+  promise(...args) {
+    return promise(this, ...args)
+  }
+
+  listen(event, listener) {
+    this.on(event, listener)
+    if (this._state === event) {
+      listener()
+    }
+    return {
+      unsuscribe() {
+        this.removeListener(event, listener)
+      },
+    }
   }
 }
 
-['on', 'addListener', 'removeListener', 'once'].forEach(name => {
+['on', 'addListener', 'removeListener', 'once', 'emit', 'listenerCount'].forEach(name => {
   EventEmitter.prototype[name] = function (...args) {
     this._emitter[name](...args)
   }

--- a/packages/events/lib/EventEmitter.js
+++ b/packages/events/lib/EventEmitter.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const promise = require('./promise')
+
+class EventEmitter {
+  constructor() {
+    this._listeners = new Map()
+  }
+  on(...args) {
+    this.addListener(...args)
+  }
+  off(...args) {
+    this.removeListener(...args)
+  }
+  addListener(event, listener) {
+    let listeners = this._listeners.get(event)
+    if (!listeners) {
+      listeners = new Set()
+      this._listeners.set(event, listeners)
+    }
+    listeners.add(listener)
+  }
+  removeListener(event, listener) {
+    const listeners = this._listeners.get(event)
+    if (listeners) {
+      listeners.delete(listener)
+      if (listeners.size === 0) {
+        this._listeners.delete(event)
+      }
+    }
+  }
+  once(event, listener) {
+    if (!listener) {
+      return promise(this, event)
+    }
+    const expire = (...args) => {
+      listener(...args)
+      this.removeListener(event, expire)
+    }
+    this.addListener(event, expire)
+  }
+  emit(event, ...values) {
+    const listeners = this._listeners.get(event)
+    if (listeners) {
+      listeners.forEach(listener => {
+        listener(...values)
+      })
+    } else if (event === 'error') {
+      const [err] = values
+      throw err instanceof Error ? err : new Error(err)
+    }
+  }
+  listenerCount(event) {
+    const listeners = this._listeners.get(event)
+    return listeners ? listeners.size : 0
+  }
+}
+
+module.exports = EventEmitter

--- a/packages/events/lib/TimeoutError.js
+++ b/packages/events/lib/TimeoutError.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = class TimeoutError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}

--- a/packages/events/lib/delay.js
+++ b/packages/events/lib/delay.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = function delay(timeout) {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout)
+  })
+}

--- a/packages/events/lib/promise.js
+++ b/packages/events/lib/promise.js
@@ -1,10 +1,10 @@
 'use strict'
 
-module.exports = function promise(EE, event) {
+module.exports = function promise(EE, event, rejectEvent) {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
       EE.removeListener(event, onEvent)
-      EE.removeListener('error', onError)
+      EE.removeListener(rejectEvent, onError)
     }
     function onError(reason) {
       reject(reason)
@@ -14,7 +14,9 @@ module.exports = function promise(EE, event) {
       resolve(value)
       cleanup()
     }
-    EE.once('error', onError)
     EE.once(event, onEvent)
+    if (rejectEvent) {
+      EE.once(rejectEvent, onError)
+    }
   })
 }

--- a/packages/events/lib/promise.js
+++ b/packages/events/lib/promise.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = function promise(EE, event, rejectEvent) {
+module.exports = function promise(EE, event, rejectEvent = 'error') {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
       EE.removeListener(event, onEvent)

--- a/packages/events/lib/promise.js
+++ b/packages/events/lib/promise.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = function promise(EE, event) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      EE.removeListener(event, onEvent)
+      EE.removeListener('error', onError)
+    }
+    function onError(reason) {
+      reject(reason)
+      cleanup()
+    }
+    function onEvent(value) {
+      resolve(value)
+      cleanup()
+    }
+    EE.once('error', onError)
+    EE.once(event, onEvent)
+  })
+}

--- a/packages/events/lib/promisify.js
+++ b/packages/events/lib/promisify.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = function promisify(fn) {
+  return (...args) => new Promise((resolve, reject) => {
+    fn(...args, (err, value) => {
+      if (err !== undefined && err !== null) {
+        reject(err)
+      } else {
+        resolve(value)
+      }
+    })
+  })
+}

--- a/packages/events/lib/timeout.js
+++ b/packages/events/lib/timeout.js
@@ -1,14 +1,10 @@
 'use strict'
 
 const TimeoutError = require('./TimeoutError')
-
-function to(ms) {
-  return new Promise((resolve, reject) => setTimeout(() => reject(new TimeoutError()), ms))
-}
+const delay = require('./delay')
 
 module.exports = function timeout(promise, ms) {
-  return Promise.race([
-    to(ms),
-    promise,
-  ])
+  return Promise.race([promise, delay(ms).then(() => {
+    throw new TimeoutError()
+  })])
 }

--- a/packages/events/lib/timeout.js
+++ b/packages/events/lib/timeout.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const TimeoutError = require('./TimeoutError')
+
+function to(ms) {
+  return new Promise((resolve, reject) => setTimeout(() => reject(new TimeoutError()), ms))
+}
+
+module.exports = function timeout(promise, ms) {
+  return Promise.race([
+    to(ms),
+    promise,
+  ])
+}

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -11,5 +11,8 @@
     "events",
     "promise",
     "EventEmitter"
-  ]
+  ],
+  "devDependencies": {
+    "zen-observable": "^0.5.1"
+  }
 }

--- a/packages/events/yarn.lock
+++ b/packages/events/yarn.lock
@@ -2,3 +2,6 @@
 # yarn lockfile v1
 
 
+zen-observable@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.5.1.tgz#a2a57908a276b569504f42fdf2fa2f643bc02d72"

--- a/packages/plugins/sasl/index.js
+++ b/packages/plugins/sasl/index.js
@@ -62,8 +62,15 @@ module.exports = plugin('sasl', {
   },
 
   handleMechanism(mech, features) {
-    return Promise.resolve(this.getCrendentials(mech, features)).then((username, password) => {
-      return this.authenticate(mech, {username, password}, features)
+    return new Promise((resolve, reject) => {
+      this.entity._status('authenticate', (username, password) => {
+        return this.authenticate(mech, {username, password}, features)
+        .then(resolve)
+        .catch(err => {
+          reject(err)
+          throw err
+        })
+      })
     })
   },
 

--- a/packages/plugins/sasl/index.js
+++ b/packages/plugins/sasl/index.js
@@ -107,6 +107,8 @@ module.exports = plugin('sasl', {
       serviceName: domain,
     }, credentials)
 
+    this.entity._status('authenticating')
+
     return new Promise((resolve, reject) => {
       const handler = element => {
         if (element.attrs.xmlns !== NS) {
@@ -132,7 +134,7 @@ module.exports = plugin('sasl', {
           ))
         } else if (element.name === 'success') {
           resolve()
-          this.entity._authenticated()
+          this.entity._status('authenticated')
         }
 
         this.entity.removeListener('nonza', handler)

--- a/packages/plugins/stream-features/index.js
+++ b/packages/plugins/stream-features/index.js
@@ -33,7 +33,7 @@ module.exports = plugin('stream-features', {
               if (feature.restart) {
                 return entity.restart()
               } else if (entity.jid) {
-                entity._online(entity.jid)
+                entity._status('online', entity.jid)
               } else {
                 this.onStreamFeatures(features, el)
               }

--- a/packages/xml/test/parse.js
+++ b/packages/xml/test/parse.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const test = require('ava')
+const parse = require('../lib/parse')
+const Element = require('../lib/Element')
+
+test('return an instance of Element', t => {
+  t.true(parse`<message/>` instanceof Element)
+})
+
+test('parses xml', t => {
+  t.is(parse`
+    <foo>
+        hello
+      <bar/>
+    </foo>
+  `.toString(), '<foo>hello<bar/></foo>')
+})


### PR DESCRIPTION
I'd like to get feedback on this.

I feel like we're lacking a status API. This PR does the following:

* Adds a status property to connection
* Adds a _status method to connection which set the status property and emit the status
* Makes connection emit status for all steps
* Replaces `_online` and `_authenticated` methods with `_status`
* Adds a `ready` method 
* returns a Promise if no cb passed to entity.once('event')

The idea behind the status property is that in addition to connection, any plugin can set it as long as it's before the online event. There must not be a "higher" status than online.

Example

```js
entity.status // 'offline'

// called every time the entity is ready
entity.ready(jid => {
  console.log('jid', jid.toString())
  entity.send(xml`<presence/>`)
})

entity.on('status', (status, ...args) => {
  logStatus(status, ...args)
})

/*
offline
starting
opening
open
authenticate
authenticating
authenticated1
restarting
opening
open
restart
online
*/
```

feedback @smokku @ggozad  ?