### PR TITLE
events, handlers and status

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@ rules:
   indent: [error, 2]
   no-multi-assign: 0
   func-names: 0
+  operator-linebreak: [error, after, {overrides: {"?": before, ":": "before" } }]
   # ES2015 http://eslint.org/docs/rules/#ecmascript-6
   prefer-rest-params: [error]
   prefer-spread: [error]

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: node_js
 node_js:
   - '6'
   - '7'
+  - '8'
 
 cache:
   yarn: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PATH := node_modules/.bin:$(PATH)
 
-.PHONY: setup test clean bundle start stop restart
+.PHONY: setup test clean bundle start stop restart size
 
 setup:
 	yarn
@@ -19,8 +19,8 @@ clean:
 	rm -f prosody/prosody.log
 	lerna clean --yes
 	rm -rf node_modules/
-	rm packages/*/dist/*.js
-	rm lerna-debug.log
+	rm -f packages/*/dist/*.js
+	rm -f lerna-debug.log
 
 bundle:
 	lerna run bundle
@@ -33,3 +33,6 @@ stop:
 
 restart:
 	./server/ctl restart
+
+size:
+	browserify packages/client-core/index.js | babili | gzip > /tmp/bundle.js.gz ; stat -c%s /tmp/bundle.js.gz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"private": true,
+  "private": true,
   "devDependencies": {
     "ava": "^0.19.1",
     "babel-cli": "^6.24.1",

--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -4,64 +4,40 @@
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
-const {client, xml} = require('./index') // For you; require('@xmpp/client')
+const {xml, client} = require('./index') // For you; require('@xmpp/client')
 const entity = client()
 
-// Emitted for any error
+// Log errors
 entity.on('error', err => {
-  console.error('error', err)
+  console.error('❌', err.toString())
 })
 
-entity.on('close', () => {
-  console.log('closed')
+// Log status changes
+entity.on('status', (status, value) => {
+  console.log('🛈', status, value ? value.toString() : '')
 })
 
-// Emitted for incoming stanza _only_ (iq/presence/message) qualified with the right namespace
-// entity.on('stanza', (stanza) => {
-//   console.log('stanza', stanza.toString())
-// })
-
-// Emitted for incoming nonza _only_
-// entity.on('nonza', (nonza) => {
-//   console.log('nonza', nonza.toString())
-// })
-
-// useful for logging raw traffic
+// Useful for logging raw traffic
 // Emitted for every incoming fragment
-entity.on('input', data => console.log('⮈ IN ', data))
+entity.on('input', data => console.log('⮈', data))
 // Emitted for every outgoing fragment
-entity.on('output', data => console.log('⮊ OUT', data))
+entity.on('output', data => console.log('⮊', data))
 
-// Emitted for any in our out XML root element
-// useful for logging
-// entity.on('element', (input, output) => {
-//   console.log(output ? 'element =>' : 'element <=', (output || input).toString())
-// })
+// Useful for logging XML traffic
+// Emitted for every incoming XML element
+// entity.on('element', data => console.log('⮈', data))
+// Emitted for every outgoing XML element
+// entity.on('send', data => console.log('⮊', data))
 
-// Emitted when the connection is established
-entity.on('connect', () => {
-  console.log('1. connected')
+entity.on('stanza', el => {
+  if (el.is('presence') && el.attrs.from === entity.jid.toString()) {
+    console.log('🗸', 'available, ready to receive <message/>')
+  }
 })
 
-// Emitted when the XMPP stream has open and we received the server stream
-entity.on('open', () => {
-  console.log('2. open')
-})
-
-// Emitted when the XMPP entity is authenticated
-entity.on('authenticated', () => {
-  console.log('3. authenticated')
-})
-
-// Emitted when authenticated and bound
 entity.on('online', jid => {
-  console.log('4. online', jid.toString())
-
-  entity.send(xml`
-    <iq id='ping' type='get'>
-      <ping xmlns='urn:xmpp:ping'/>
-    </iq>
-  `)
+  console.log('jid', jid.toString())
+  entity.send(xml`<presence/>`)
 })
 
 // "start" opens the socket and the XML stream
@@ -70,24 +46,18 @@ entity.start('localhost') // Auto
 // entity.start('xmpps://localhost:5223') // TLS
 // entity.start('ws://localhost:5280/xmpp-websocket') // Websocket
 // entity.start('wss://localhost:5281/xmpp-websocket') // Secure WebSocket
-  // resolves once online
-  .then(jid => {
-    console.log('started', jid.toString())
-  })
-  // Rejects for any error before online
   .catch(err => {
     console.error('start failed', err)
   })
 
-// Emitted when authentication is required
-entity.on('authenticate', authenticate => {
-  authenticate('node-xmpp', 'foobar')
-    .then(() => {
-      console.log('authenticated')
-    })
-    .catch(err => {
-      console.error('authentication failed', err)
-    })
+// Handle authentication to provide credentials
+entity.handle('authenticate', authenticate => {
+  return authenticate('node-xmpp', 'foobar')
+})
+
+// Handle binding to choose resource - optional
+entity.handle('bind', bind => {
+  return bind('example')
 })
 
 process.on('unhandledRejection', (reason, p) => {

--- a/packages/client/lib/Client.js
+++ b/packages/client/lib/Client.js
@@ -13,19 +13,6 @@ class Client extends ClientCore {
       } // Browserify stub
       this.plugin(plugin)
     })
-
-    // So that we have a common inteface with component
-    const {sasl} = this.plugins
-    sasl.handleMechanism = (mech, features) => new Promise((resolve, reject) => {
-      this.emit('authenticate', (username, password) => {
-        return sasl.authenticate(mech, {username, password}, features)
-        .then(resolve)
-        .catch(err => {
-          reject(err)
-          throw err
-        })
-      })
-    })
   }
 }
 

--- a/packages/component-core/index.js
+++ b/packages/component-core/index.js
@@ -38,23 +38,23 @@ class Component extends Connection {
   // https://xmpp.org/extensions/xep-0114.html#example-3
   open(...args) {
     return super.open(...args).then(el => {
-      this.emit('authenticate', secret => {
-        return this.authenticate(el.attrs.id, secret)
-      })
+      this._status('authenticate')
+      return this.delegate('authenticate', secret => this.authenticate(el.attrs.id, secret))
     })
   }
 
   // https://xmpp.org/extensions/xep-0114.html#example-3
   authenticate(id, password) {
+    this._status('authenticating')
     const hash = crypto.createHash('sha1')
     hash.update(id + password, 'binary')
     return this.sendReceive(xml`<handshake>${hash.digest('hex')}</handshake>`).then(el => {
       if (el.name !== 'handshake') {
         throw new Error('unexpected stanza')
       }
-      this._authenticated()
+      this._status('authenticated')
       this._jid(this.domain)
-      this._online()
+      this._status('online', this.jid)
     })
   }
 }

--- a/packages/component-core/test/test.js
+++ b/packages/component-core/test/test.js
@@ -6,7 +6,7 @@ const Component = require('..')
 
 test('calling send sanitize the from attribute', t => {
   const entity = new Component()
-  entity.write = () => {}
+  entity.write = () => Promise.resolve()
   let el
 
   el = xml`<el/>`
@@ -26,7 +26,7 @@ test('calling send sanitize the from attribute', t => {
 
 test('calling send sanitize the to attribute', t => {
   const entity = new Component()
-  entity.write = () => {}
+  entity.write = () => Promise.resolve()
   let el
 
   el = xml`<el/>`

--- a/packages/connection-tcp/index.js
+++ b/packages/connection-tcp/index.js
@@ -12,9 +12,9 @@ const NS_STREAM = 'http://etherx.jabber.org/streams'
 class TCP extends Connection {
   socketParameters(uri) {
     const {port, host, protocol} = super.socketParameters(uri)
-    return (protocol === 'xmpp:') ?
-      {port, host} :
-      undefined
+    return (protocol === 'xmpp:')
+      ? {port, host}
+      : undefined
   }
 
   // https://xmpp.org/rfcs/rfc6120.html#streams-open

--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const EventEmitter = require('@xmpp/events')
+const {timeout, EventEmitter, promise} = require('@xmpp/events')
 const jid = require('@xmpp/jid')
 const url = require('url')
 const xml = require('@xmpp/xml')
@@ -45,23 +45,24 @@ class Connection extends EventEmitter {
     this.openOptions = null
     this.connectOptions = null
     this.socketListeners = Object.create(null)
+    this.status = 'offline'
   }
 
   _attachSocket(socket) {
     const sock = this.socket = socket
     const listeners = this.socketListeners
     listeners.data = data => {
-      data = data.toString('utf8')
-      this.emit('input', data)
-      this.parser.write(data)
+      const str = data.toString('utf8')
+      this.emit('input', str)
+      this.parser.write(str)
     }
     listeners.close = () => {
       this.domain = ''
       this.jid = null
-      this.emit('close')
+      this._status('close')
     }
     listeners.connect = () => {
-      this.emit('connect')
+      this._status('connect')
     }
     listeners.error = error => {
       this.emit('error', error)
@@ -106,49 +107,50 @@ class Connection extends EventEmitter {
     return this.jid
   }
 
-  _online() {
-    this.emit('online', this.jid)
-  }
-
-  _authenticated() {
-    this.emit('authenticated')
+  _status(status, ...args) {
+    this.status = status
+    this.emit('status', status, ...args)
+    this.emit(status, ...args)
   }
 
   /**
    * Opens the socket then opens the stream
    */
   start(options) {
-    return new Promise((resolve, reject) => {
-      if (typeof options === 'string') {
-        options = {uri: options}
-      }
+    this._status('starting')
+    if (typeof options === 'string') {
+      options = {uri: options}
+    }
 
-      if (!options.domain) {
-        options.domain = getHostname(options.uri)
-      }
+    if (!options.domain) {
+      options.domain = getHostname(options.uri)
+    }
 
-      this.promise('online').then(resolve, reject)
+    return Promise.all([
+      this.promise('online'),
       this.connect(options.uri).then(() => {
         const {domain, lang} = options
         return this.open({domain, lang})
-      }, reject)
-    })
+      }),
+    ]).then(([addr]) => addr)
   }
 
   /**
    * Closes the stream then closes the socket
    */
   stop() {
+    this._status('stopping')
     return new Promise((resolve, reject) => {
       this.close().catch(reject) // FIXME wait footer
-      this.end().then(resolve, reject)
+      this.disconnect().then(resolve, reject)
     })
   }
 
   /**
-   * Opens the socket
+   * Connects the socket
    */
   connect(options) {
+    this._status('connecting')
     this.connectOptions = options
     return new Promise((resolve, reject) => {
       this._attachParser(new this.Parser())
@@ -157,19 +159,24 @@ class Connection extends EventEmitter {
       this.socket.connect(this.socketParameters(options), () => {
         this.socket.removeListener('error', reject)
         resolve()
+        // The 'connect' status is emitted by the socket 'connect' listener
       })
     })
   }
 
   /**
-   * Closes the socket
+   * Disconnects the socket
    */
-  end() {
+  disconnect() {
+    this._status('disconnecting')
     return new Promise(resolve => {
        // TODO timeout
       const handler = () => {
         this.socket.end()
-        this.once('close', resolve)
+        this.once('close', () => {
+          resolve()
+          this._status('disconnected')
+        })
       }
       this.parser.once('end', handler)
     })
@@ -179,20 +186,21 @@ class Connection extends EventEmitter {
    * Opens the stream
    */
   open(options) {
+    this._status('opening')
     this.openOptions = options
     if (typeof options === 'string') {
       options = {domain: options}
     }
-    return new Promise((resolve, reject) => {
-      const {domain, lang} = options
 
-      const headerElement = this.headerElement()
-      headerElement.attrs.to = domain
-      headerElement.attrs['xml:lang'] = lang
+    const {domain, lang} = options
 
-      this.write(this.header(headerElement))
+    const headerElement = this.headerElement()
+    headerElement.attrs.to = domain
+    headerElement.attrs['xml:lang'] = lang
 
-      this.parser.once('startElement', el => {
+    return Promise.all([
+      this.write(this.header(headerElement)),
+      promise(this.parser, 'startElement').then(el => {
         // FIXME what about version and xmlns:stream ?
         if (
           el.name !== headerElement.name ||
@@ -200,70 +208,60 @@ class Connection extends EventEmitter {
           el.attrs.from !== headerElement.attrs.to ||
           !el.attrs.id
         ) {
-          return this.once('error', reject)
+          return this.promise('error')
         }
 
         this.domain = domain
         this.lang = el.attrs['xml:lang']
-        resolve(el)
-        this.emit('open', el)
-      })
-    })
+        this._status('open', el)
+        return el
+      }),
+    ]).then(([, el]) => el)
   }
 
   /**
    * Closes the stream
    */
   close() {
-    return this.promiseWrite(this.footer(this.footerElement()))
+    this._status('closing')
+    return this.write(this.footer(this.footerElement()))
+    // The 'close' status is emitted by the socket 'close' listener
   }
 
   /**
-   * Restarts the stream
+   * Restart the stream
+   * https://xmpp.org/rfcs/rfc6120.html#streams-negotiation-restart
    */
   restart() {
-    return this.open(this.openOptions)
+    this._status('restarting')
+    return this.open(this.openOptions).then(() => {
+      this._status('restart')
+    })
   }
 
   send(element) {
-    return this.promiseWrite(element).then(() => {
+    return this.write(element).then(() => {
       this.emit('send', element)
     })
   }
 
-  sendReceive(element, timeout = this.timeout) {
-    return new Promise((resolve, reject) => {
-      this.send(element).catch(reject)
-      this.promise('element', timeout).then(resolve, reject)
-    })
+  sendReceive(element, ms = this.timeout) {
+    return Promise.all([
+      this.send(element),
+      timeout(this.promise('element'), ms),
+    ]).then(([, el]) => el)
   }
 
-  promiseWrite(data) {
+  write(data) {
     return new Promise((resolve, reject) => {
-      this.write(data, err => {
+      const str = data.toString('utf8')
+      this.socket.write(str, err => {
         if (err) {
           return reject(err)
         }
+        this.emit('output', str)
         resolve()
       })
-    })
-  }
-
-  write(data, fn = () => {}) {
-    data = data.toString('utf8')
-    this.socket.write(data, err => {
-      if (err) {
-        return fn(err)
-      }
-      this.emit('output', data)
-      fn()
-    })
-  }
-
-  writeReceive(data, timeout = this.timeout) {
-    return new Promise((resolve, reject) => {
-      this.promiseWrite(data).catch(reject)
-      this.promise('element', timeout).then(resolve, reject)
     })
   }
 

--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -2,17 +2,9 @@
 
 module.exports = function debug(entity) {
   if (process.env.XMPP_DEBUG) {
-    entity.on('input', data => console.log('⮈ IN ', data))
-    entity.on('output', data => console.log('⮊ OUT', data))
-    ;['connect', 'open', 'authenticated', 'online', 'error', 'authenticate'].forEach(event => {
-      const prefix = (event === 'error' ? '❌   ' : '🛈   ')
-      entity.on(event, arg => {
-        if (arg === undefined || arg === null || typeof arg === 'function') {
-          console.log(prefix, event)
-        } else {
-          console.log(prefix, event, arg.toString())
-        }
-      })
-    })
+    entity.on('input', data => console.log('⮈', data))
+    entity.on('output', data => console.log('⮊', data))
+    entity.on('error', err => console.error('❌', err))
+    entity.on('status', (status, value) => console.log('🛈', status, value ? value.toString() : ''))
   }
 }

--- a/packages/events/index.js
+++ b/packages/events/index.js
@@ -1,87 +1,14 @@
 'use strict'
 
-class TimeoutError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'TimeoutError'
-  }
-}
-TimeoutError.prototype.name = 'TimeoutError'
+const timeout = require('./lib/timeout')
+const delay = require('./lib/delay')
+const TimeoutError = require('./lib/TimeoutError')
+const promise = require('./lib/promise')
+const EventEmitter = require('./lib/EventEmitter')
 
-class EventEmitter {
-  constructor() {
-    this._listeners = new Map()
-  }
-  on(...args) {
-    this.addListener(...args)
-  }
-  off(...args) {
-    this.removeListener(...args)
-  }
-  addListener(event, listener) {
-    let listeners = this._listeners.get(event)
-    if (!listeners) {
-      listeners = new Set()
-      this._listeners.set(event, listeners)
-    }
-    listeners.add(listener)
-  }
-  removeListener(event, listener) {
-    const listeners = this._listeners.get(event)
-    if (listeners) {
-      listeners.delete(listener)
-      if (listeners.size === 0) {
-        this._listeners.delete(event)
-      }
-    }
-  }
-  once(event, listener) {
-    const expire = (...args) => {
-      listener(...args)
-      this.removeListener(event, expire)
-    }
-    this.addListener(event, expire)
-  }
-  promise(event, timeout) {
-    return new Promise((resolve, reject) => {
-      let timer
-      const cleanup = () => {
-        this.removeListener(event, onEvent)
-        this.removeListener('error', onError)
-        clearTimeout(timer)
-      }
-      if (typeof timeout === 'number') {
-        timer = setTimeout(() => {
-          reject(new TimeoutError(`"${event}" event didn't fire within ${timeout}ms`))
-          cleanup()
-        }, timeout)
-      }
-      function onError(reason) {
-        reject(reason)
-        cleanup()
-      }
-      function onEvent(value) {
-        resolve(value)
-        cleanup()
-      }
-      this.once('error', onError)
-      this.once(event, onEvent)
-    })
-  }
-  emit(event, arg) {
-    const listeners = this._listeners.get(event)
-    if (listeners) {
-      listeners.forEach(listener => {
-        listener(arg)
-      })
-    } else if (event === 'error') {
-      throw arg instanceof Error ? arg : new Error(arg)
-    }
-  }
-  listenerCount(event) {
-    const listeners = this.listeners.get(event)
-    return listeners ? listeners.size : 0
-  }
-}
-
-module.exports = EventEmitter
+exports = module.exports = EventEmitter
+exports.EventEmitter = EventEmitter
+exports.timeout = timeout
+exports.delay = delay
+exports.TimeoutError = TimeoutError
+exports.promise = promise

--- a/packages/events/lib/EventEmitter.js
+++ b/packages/events/lib/EventEmitter.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const _EventEmitter = require('events')
+const promiseEvent = require('./promise')
+
+class EventEmitter {
+  constructor() {
+    this._emitter = new _EventEmitter()
+    this._handlers = Object.create(null)
+  }
+
+  promise(...args) {
+    return promiseEvent(this, ...args)
+  }
+
+  handle(event, handler) {
+    this._handlers[event] = handler
+  }
+
+  delegate(event, ...args) {
+    const handler = this._handlers[event]
+    if (!handler) {
+      throw new Error(`${event} has no handler attached.`)
+    }
+    const promise = handler(...args)
+    if (!(promise instanceof Promise)) {
+      throw new TypeError(`${event} handler must return a promise.`)
+    }
+    return promise
+  }
+
+  isHandled(event) {
+    return Boolean(this._handlers[event])
+  }
+}
+
+['on', 'addListener', 'removeListener', 'once', 'emit', 'listenerCount'].forEach(name => {
+  EventEmitter.prototype[name] = function (...args) {
+    this._emitter[name](...args)
+  }
+})
+
+module.exports = EventEmitter

--- a/packages/events/lib/TimeoutError.js
+++ b/packages/events/lib/TimeoutError.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = class TimeoutError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}

--- a/packages/events/lib/delay.js
+++ b/packages/events/lib/delay.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = function delay(timeout) {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout)
+  })
+}

--- a/packages/events/lib/promise.js
+++ b/packages/events/lib/promise.js
@@ -1,0 +1,22 @@
+'use strict'
+
+module.exports = function promise(EE, event, rejectEvent = 'error') {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      EE.removeListener(event, onEvent)
+      EE.removeListener(rejectEvent, onError)
+    }
+    function onError(reason) {
+      reject(reason)
+      cleanup()
+    }
+    function onEvent(value) {
+      resolve(value)
+      cleanup()
+    }
+    EE.once(event, onEvent)
+    if (rejectEvent) {
+      EE.once(rejectEvent, onError)
+    }
+  })
+}

--- a/packages/events/lib/timeout.js
+++ b/packages/events/lib/timeout.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const TimeoutError = require('./TimeoutError')
+const delay = require('./delay')
+
+module.exports = function timeout(promise, ms) {
+  return Promise.race([promise, delay(ms).then(() => {
+    throw new TimeoutError()
+  })])
+}

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -11,5 +11,9 @@
     "events",
     "promise",
     "EventEmitter"
-  ]
+  ],
+  "devDependencies": {},
+  "dependencies": {
+    "util.promisify": "^1.0.0"
+  }
 }

--- a/packages/events/yarn.lock
+++ b/packages/events/yarn.lock
@@ -2,3 +2,76 @@
 # yarn lockfile v1
 
 
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+es-abstract@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    is-callable "^1.1.3"
+    is-regex "^1.0.3"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
+function-bind@^1.0.2, function-bind@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
+
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-regex@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"

--- a/packages/plugins/bind/index.js
+++ b/packages/plugins/bind/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const xml = require('@xmpp/xml')
+const {plugin, xml} = require('@xmpp/plugin')
 const streamfeatures = require('../stream-features')
 const iqCaller = require('../iq-caller')
 
@@ -23,32 +23,28 @@ function match(features) {
   return features.getChild('bind', NS)
 }
 
-function bind(caller, entity, resource) {
-  return caller.set(makeBindElement(resource)).then(result => {
-    entity._jid(result.getChildText('jid'))
-  })
-}
-
-module.exports.name = 'bind'
-module.exports.plugin = function plugin(entity) {
-  const caller = entity.plugin(iqCaller)
-  const p = {
-    entity,
-    getResource() {},
-  }
-
-  const streamFeature = {
-    name: 'bind',
-    priority: 2500,
-    match,
-    run: entity => {
-      return Promise.resolve((p.getResource())).then(resource => {
-        return bind(caller, entity, resource)
-      })
-    },
-  }
-
-  const streamFeatures = entity.plugin(streamfeatures)
-  streamFeatures.add(streamFeature)
-  return p
-}
+module.exports = plugin('bind', {
+  start() {
+    const streamFeature = {
+      name: 'bind',
+      priority: 2500,
+      match,
+      run: () => this.handleFeature(),
+    }
+    this.plugins['stream-features'].add(streamFeature)
+  },
+  bind(resource) {
+    this.entity._status('binding')
+    return this.plugins['iq-caller'].set(makeBindElement(resource)).then(result => {
+      this.entity._jid(result.getChildText('jid'))
+      this.entity._status('bound')
+    })
+  },
+  handleFeature() {
+    const {entity} = this
+    entity._status('bind')
+    return entity.isHandled('bind')
+      ? entity.delegate('bind', resource => this.bind(resource))
+      : this.bind()
+  },
+}, [streamfeatures, iqCaller])

--- a/packages/plugins/sasl/index.js
+++ b/packages/plugins/sasl/index.js
@@ -57,12 +57,13 @@ module.exports = plugin('sasl', {
 
     return Promise.resolve(this.getMechanism(offered, usable, available, features)).then(mech => {
       this.mech = mech
-      return Promise.resolve(this.handleMechanism(mech, features))
+      return this.handleMechanism(mech, features)
     })
   },
 
   handleMechanism(mech, features) {
-    return Promise.resolve(this.getCrendentials(mech, features)).then((username, password) => {
+    this.entity._status('authenticate')
+    return this.entity.delegate('authenticate', (username, password) => {
       return this.authenticate(mech, {username, password}, features)
     })
   },
@@ -107,6 +108,8 @@ module.exports = plugin('sasl', {
       serviceName: domain,
     }, credentials)
 
+    this.entity._status('authenticating')
+
     return new Promise((resolve, reject) => {
       const handler = element => {
         if (element.attrs.xmlns !== NS) {
@@ -132,7 +135,7 @@ module.exports = plugin('sasl', {
           ))
         } else if (element.name === 'success') {
           resolve()
-          this.entity._authenticated()
+          this.entity._status('authenticated')
         }
 
         this.entity.removeListener('nonza', handler)

--- a/packages/plugins/stream-features/index.js
+++ b/packages/plugins/stream-features/index.js
@@ -33,7 +33,7 @@ module.exports = plugin('stream-features', {
               if (feature.restart) {
                 return entity.restart()
               } else if (entity.jid) {
-                entity._online(entity.jid)
+                entity._status('online', entity.jid)
               } else {
                 this.onStreamFeatures(features, el)
               }

--- a/packages/plugins/tls/lib/Connection.js
+++ b/packages/plugins/tls/lib/Connection.js
@@ -7,9 +7,9 @@ const Connection = require('@xmpp/connection')
 class ConnectionTLS extends ConnectionTCP {
   socketParameters(URI) {
     const {port, host, protocol} = Connection.prototype.socketParameters(URI)
-    return (protocol === 'xmpps:') ?
-      {port: port || 5223, host} :
-      undefined
+    return (protocol === 'xmpps:')
+      ? {port: port || 5223, host}
+      : undefined
   }
 }
 

--- a/packages/xml/test/parse.js
+++ b/packages/xml/test/parse.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const test = require('ava')
+const parse = require('../lib/parse')
+const Element = require('../lib/Element')
+
+test('return an instance of Element', t => {
+  t.true(parse`<message/>` instanceof Element)
+})
+
+test('parses xml', t => {
+  t.is(parse`
+    <foo>
+        hello
+      <bar/>
+    </foo>
+  `.toString(), '<foo>hello<bar/></foo>')
+})

--- a/test/client.js
+++ b/test/client.js
@@ -15,10 +15,6 @@ test.beforeEach(t => {
   const entity = client()
   debug(entity)
   t.context.entity = entity
-
-  entity.on('authenticate', auth => {
-    auth(USERNAME, PASSWORD)
-  })
 })
 
 test.afterEach(t => {
@@ -41,8 +37,9 @@ test.cb('client', t => {
     t.true(el instanceof xml.Element)
   })
 
-  entity.on('authenticate', auth => {
+  entity.handle('authenticate', auth => {
     t.is(typeof auth, 'function')
+    return auth(USERNAME, PASSWORD)
   })
 
   entity.on('online', id => {
@@ -73,13 +70,14 @@ test.cb('bad credentials', t => {
   entity.on('authenticated', () => t.fail())
   entity.on('online', () => t.fail())
 
-  entity.on('authenticate', auth => {
-    auth('foo', 'bar')
+  entity.handle('authenticate', auth => {
+    return auth('foo', 'bar')
     .then(() => t.fail())
     .catch(err => {
       t.true(err instanceof Error)
       t.is(err.condition, 'not-authorized')
       error = err
+      throw err
     })
   })
 
@@ -95,46 +93,70 @@ test.cb('bad credentials', t => {
     })
 })
 
-// Prosody 404
+// Prosody 404 https://prosody.im/issues/issue/932
 test.skip('ws IPv4', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start({uri: 'ws://127.0.0.1:5280/xmpp-websocket', domain})
     .then(id => t.is(id.bare().toString(), JID))
 })
 
-// Prosody 404
+// Prosody 404 https://prosody.im/issues/issue/932
 test.skip('ws IPv6', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start({uri: 'ws://[::1]:5280/xmpp-websocket', domain})
     .then(id => t.is(id.bare().toString(), JID))
 })
 
 test('ws domain', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start('ws://localhost:5280/xmpp-websocket')
     .then(id => t.is(id.bare().toString(), JID))
 })
 
-// Prosody 404
+// Prosody 404 https://prosody.im/issues/issue/932
 test.skip('wss IPv4', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start({uri: 'wss://127.0.0.1:5281/xmpp-websocket', domain})
     .then(id => t.is(id.bare().toString(), JID))
 })
 
-// Prosody 404
+// Prosody 404 https://prosody.im/issues/issue/932
 test.skip('wss IPv6', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start({uri: 'wss://[::1]:5281/xmpp-websocket', domain})
     .then(id => t.is(id.bare().toString(), JID))
 })
 
 test('wss domain', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start('wss://localhost:5281/xmpp-websocket')
     .then(id => t.is(id.bare().toString(), JID))
 })
 
 test('xmpp IPv4', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start({uri: 'xmpp://127.0.0.1:5222', domain})
     .then(id => t.is(id.bare().toString(), JID))
 })
 
 test.skip('xmpp IPv6', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   // No local IPv6 on travis https://github.com/travis-ci/travis-ci/issues/4964
   if (process.env.TRAVIS) {
     return t.pass()
@@ -144,16 +166,25 @@ test.skip('xmpp IPv6', t => {
 })
 
 test('xmpp domain', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start('xmpp://localhost:5222')
     .then(id => t.is(id.bare().toString(), JID))
 })
 
 test('xmpps IPv4', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start({uri: 'xmpps://127.0.0.1:5223', domain})
     .then(id => t.is(id.bare().toString(), JID))
 })
 
 test('xmpps IPv6', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   // No local IPv6 on travis https://github.com/travis-ci/travis-ci/issues/4964
   if (process.env.TRAVIS) {
     return t.pass()
@@ -163,6 +194,9 @@ test('xmpps IPv6', t => {
 })
 
 test('xmpps domain', t => {
+  t.context.entity.handle('authenticate', auth => {
+    return auth(USERNAME, PASSWORD)
+  })
   return t.context.entity.start('xmpps://localhost:5223')
     .then(id => t.is(id.bare().toString(), JID))
 })

--- a/test/component.js
+++ b/test/component.js
@@ -26,9 +26,9 @@ test.cb('component', t => {
     t.true(el instanceof xmpp.xml.Element)
   })
 
-  entity.on('authenticate', auth => {
+  entity.handle('authenticate', auth => {
     t.is(typeof auth, 'function')
-    auth('foobar').then(() => t.pass())
+    return auth('foobar').then(() => t.pass())
   })
 
   entity.on('online', jid => {


### PR DESCRIPTION
cc @ggozad @smokku 

# What's new

## status event

Use this to log status.

```js
client.on('status', (status, value) => {
  console.log('status', value ? value.toString() : '')
})
```

## handler interface

See Breaking changes

## new events

opening, starting, closing, authenticating, ...

# Breaking changes

## write

`entity.write()` now returns a promise and replace `promiseWrite()`

## authenticate and bind events

`authenticate`, `bind`, ... events do not pass a function anymore, use `handle` instead of `on` to handle those.

Example
```js
client.handle('authentication', (authenticate) => {
  return authenticate('foo', 'bar')
    // optional
    // handle error if you want
    // but make sure to throw it afterwards to pass it along the `.start` promise chain
    .catch(err => {
      console.error('authentication failed', err.toString())
      throw err
    })
})
```

# Why

https://github.com/node-xmpp/node-xmpp/pull/418#issuecomment-305183091

I'm not implementing the `listen` interface for now, I don't think it's useful with the new `handle` interface.

and

https://github.com/node-xmpp/node-xmpp/commit/5295b8e2c28889f251145f82e052ebafc2e0982f#commitcomment-22368964

