### PR TITLE
fix client reconnection when resolve plugin is enabled

### DIFF
--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -31,7 +31,7 @@ entity.on('output', data => console.log('⮊', data))
 
 entity.on('stanza', el => {
   if (el.is('presence') && el.attrs.from === entity.jid.toString()) {
-    console.log('🗸', 'available, ready to receive <message/>')
+    console.log('🗸', 'available, ready to receive <message/>s')
   }
 })
 

--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -142,8 +142,6 @@ class Connection extends EventEmitter {
       return Promise.reject(new Error('Connection is not offline'))
     }
 
-    this._status('starting')
-
     this.startOptions = options
 
     if (typeof options === 'string') {
@@ -240,7 +238,6 @@ class Connection extends EventEmitter {
     if (!this.socket) {
       return Promise.resolve()
     }
-    this._status('stopping')
     return this.close().then(el => this.disconnect().then(() => {
       this._status('offline')
       return el

--- a/packages/plugins/reconnect/index.js
+++ b/packages/plugins/reconnect/index.js
@@ -40,15 +40,15 @@ module.exports = plugin('reconnect', {
     listeners.disconnect = () => {
       this.reconnect()
     }
-    listeners.starting = () => {
+    listeners.online = () => {
       this.entity.on('disconnect', listeners.disconnect)
     }
     this.listeners = listeners
-    this.entity.once('starting', listeners.starting)
+    this.entity.once('online', listeners.online)
   },
 
   stop() {
     this.stopped()
-    this.entity.removeListener('connect', this.listeners.connect)
+    this.entity.removeListener('online', this.listeners.online)
   },
 })

--- a/packages/plugins/resolve/index.js
+++ b/packages/plugins/resolve/index.js
@@ -51,7 +51,7 @@ function fallbackConnect(entity, uris) {
     .then(() => {
       entity._attachParser(parser)
       entity._attachSocket(socket)
-      entity.emit('connect')
+      socket.emit('connect')
       entity.Transport = Transport
       entity.Socket = Transport.prototype.Socket
       entity.Parser = Transport.prototype.Parser


### PR DESCRIPTION
* removes `starting` status
* removes `stopping` status
* fix client reconnection when resolve plugin is enabled (introduced in last PR)  +  add client reconnection tests