### PR TITLE
Add support for custom registration fields

### DIFF
--- a/packages/node-xmpp-client/lib/Client.js
+++ b/packages/node-xmpp-client/lib/Client.js
@@ -370,7 +370,10 @@ Client.prototype.doRegister = function () {
     to: this.jid.domain
   }).c('query', {xmlns: NS_REGISTER})
     .c('username').t(this.jid.local).up()
-    .c('password').t(this.password)
+    .c('password').t(this.password).up()
+  for (var key in this.options.registrationOptions) {
+    iq.c(key).t(this.options.registrationOptions[key]).up()
+  }
   this.send(iq)
 
   var self = this

--- a/packages/node-xmpp-server/lib/C2S/Session.js
+++ b/packages/node-xmpp-server/lib/C2S/Session.js
@@ -246,12 +246,16 @@ Session.prototype.onRegistration = function (stanza) {
     proceed()
   } else if (stanza.attrs.type === 'set') {
     var jid = new JID(register.getChildText('username'), this.server.options.domain)
-    this.emit('register', {
+    var opts = {
       jid: jid,
       username: register.getChildText('username'),
       password: register.getChildText('password'),
       client: self
-    }, function (error) {
+    }
+    for (var child in register.children) {
+      opts[register.children[child].name] = register.children[child].getText()
+    }
+    this.emit('register', opts, function (error) {
       if (!error) {
         self.emit('registration-success', self.jid)
       } else {


### PR DESCRIPTION
Fixes #431 

This allows the client to specify fields that will be sent with the registration, and then passes all of them to the server register emit. 

I couldn't see any existing appropriate tests for these, and didn't have time to make any from scratch today. 